### PR TITLE
Do not hardcode ME param card path

### DIFF
--- a/confs/example.lua
+++ b/confs/example.lua
@@ -115,6 +115,7 @@ end
 
 MatrixElement.ttbar = {
   pdf = 'CT10nlo',
+  card = '../ME/Cards/param_card.dat',
 
   initialState = 'boost::output',
 

--- a/modules/MatrixElement.cc
+++ b/modules/MatrixElement.cc
@@ -81,7 +81,8 @@ class MatrixElement: public Module {
                 m_jacobians.push_back(get<double>(tag));
             }
 
-            m_ME_parameters.reset(new Parameters_sm("/home/sbrochet/Recherche/CP3/MEMpp/Modules/ME/Cards/param_card.dat"));
+            std::string param_card = parameters.get<std::string>("card");
+            m_ME_parameters.reset(new Parameters_sm(param_card));
             m_ME.reset(new cpp_pp_ttx_fullylept(*m_ME_parameters));
 
             // PDF


### PR DESCRIPTION
Read the ME param card from the config instead of hardcoding the path. This and #4 allows MoMEMta to run on ingrid :laughing: 