### PR TITLE
Added permutator module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ set(MOMEMTA_SOURCES
     "modules/Flatter.cc"
     "modules/GaussianTransferFunction.cc"
     "modules/MatrixElement.cc"
+    "modules/Permutator.cc"
     "core/src/ConfigurationReader.cc"
     "core/src/ConfigurationSet.cc"
     "core/src/InputTag.cc"

--- a/confs/example.lua
+++ b/confs/example.lua
@@ -18,7 +18,7 @@ USE_TF = true
 
 if USE_TF then
     -- With transfer functions
-    inputs = {
+    inputs_before_perm = {
         'tf_p1::output',
         'tf_p2::output',
         'tf_p3::output',
@@ -26,12 +26,27 @@ if USE_TF then
     }
 else
     -- No transfer functions
-    inputs = {
+    inputs_before_perm = {
         'input::particles/0',
         'input::particles/1',
         'input::particles/2',
         'input::particles/3',
     }
+end
+
+USE_PERM = true
+
+if USE_PERM then
+  -- Use permutator module to permutate input particles 0 and 2 using the MC
+  inputs = {
+    inputs_before_perm[1],
+    'permutator::output/0',
+    inputs_before_perm[3],
+    'permutator::output/1',
+  }
+else
+  -- No permutation, take particles as they come
+  inputs = inputs_before_perm
 end
 
 configuration = {
@@ -91,6 +106,21 @@ if USE_TF then
         ps_point = 'cuba::ps_points/7',
         reco_particle = 'input::particles/3',
         sigma = 0.10,
+    }
+end
+
+if USE_PERM then
+    cuba_index = '4'
+    if USE_TF then
+        cuba_index = '8'
+    end
+    
+    Permutator.permutator = {
+        ps_point = 'cuba::ps_points/' .. cuba_index,
+        input = {
+          inputs_before_perm[2],
+          inputs_before_perm[4],
+        }
     }
 end
 

--- a/modules/Permutator.cc
+++ b/modules/Permutator.cc
@@ -1,0 +1,72 @@
+/*
+ *  MoMEMta: a modular implementation of the Matrix Element Method
+ *  Copyright (C) 2016  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <algorithm>
+#include <cmath>
+
+#include <TMath.h>
+
+#include <momemta/ConfigurationSet.h>
+#include <momemta/Module.h>
+#include <momemta/Types.h>
+
+class Permutator: public Module {
+    public:
+
+        Permutator(PoolPtr pool, const ConfigurationSet& parameters): Module(pool, parameters.getModuleName()),
+            m_ps_point(parameters.get<InputTag>("ps_point")),
+            m_input(parameters.get<std::vector<InputTag>>("input"))
+        {
+            
+            m_ps_point.resolve(pool);
+            for (auto& t: m_input)
+                t.resolve(pool);
+
+            std::vector<uint32_t> tmp;
+            for(uint32_t i = 0; i < m_input.size(); i++)
+                tmp.push_back(i);
+            do {
+                perm_indices.push_back(tmp);
+            } while( std::next_permutation(tmp.begin(), tmp.end()) );
+
+            (*m_output).resize(m_input.size());
+        };
+
+        virtual void work() override {
+            double psPoint = m_ps_point.get<double>();
+            
+            uint32_t chosen_perm = std::lround(psPoint*(perm_indices.size()-1));
+            
+            for(uint32_t i = 0; i < m_input.size(); i++)
+                (*m_output)[i] = m_input[ perm_indices[chosen_perm][i] ].get<LorentzVector>();
+        }
+
+        virtual size_t dimensions() const override {
+            return 1;
+        }
+
+    private:
+        InputTag m_ps_point;
+        std::vector<InputTag> m_input;
+
+        std::shared_ptr<std::vector<LorentzVector>> m_output = produce<std::vector<LorentzVector>>("output");
+
+        std::vector<std::vector<uint32_t>> perm_indices;
+};
+REGISTER_MODULE(Permutator);
+


### PR DESCRIPTION
This PR introduces the new module "Permutator" to handle Monte-Carlo integration of the permutations of identical particles. 

It adds a dimension of integration, and using this extra phase-space point, decides which permutation to use to permutate the entries in the "input" table to produce the "output" table.

In the example config, add an option "USE_PERM" to decide if the module is used or not. If it is, it takes the two input b-jets (which either come out of the TFs or come directly from the user if no TF is used) and handles the permutation. Its output is then passed with the rest (i.e., the leptons) to the BlockD module.