### PR TITLE
Use a graph to represent modules dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ set(MOMEMTA_SOURCES
     "modules/Permutator.cc"
     "core/src/ConfigurationReader.cc"
     "core/src/ConfigurationSet.cc"
+    "core/src/Graph.cc"
     "core/src/InputTag.cc"
     "core/src/LibraryManager.cc"
     "core/src/logging.cc"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,9 @@ if (NOT USE_BUILTIN_LUA)
     find_package(Lua QUIET)
 endif()
 
+set(Boost_NO_BOOST_CMAKE ON)
+find_package(Boost REQUIRED)
+
 # Include external
 set(EXTERNAL_DIR "${PROJECT_SOURCE_DIR}/external")
 add_subdirectory(external)
@@ -119,6 +122,7 @@ include_directories(SYSTEM ${EXTERNAL_DIR}/spdlog)
 include_directories(SYSTEM ${LUA_INCLUDE_DIR})
 include_directories(SYSTEM ${LHAPDF_INCLUDE_DIRS})
 include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 target_link_libraries(momemta LINK_PUBLIC dl)
 target_link_libraries(momemta LINK_PRIVATE cuba)

--- a/core/include/Graph.h
+++ b/core/include/Graph.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <momemta/Module.h>
+
+#include <boost/config.hpp>
+#include <boost/graph/adjacency_list.hpp>
+
+#include <string>
+#include <vector>
+
+/// Generic graph representation of the module hierarchy
+namespace graph {
+
+struct Vertex {
+    std::string name;
+    ModulePtr module;
+    uint32_t id;
+};
+
+struct Edge {
+    std::string name;
+};
+
+typedef boost::adjacency_list<boost::listS, boost::listS, boost::bidirectionalS, Vertex, Edge> Graph;
+
+typedef boost::graph_traits<Graph>::vertex_descriptor vertex_t;
+typedef boost::graph_traits<Graph>::edge_descriptor edge_t;
+
+/**
+ * \brief Build a graph representation of the modules.
+ *
+ * The graph allows us to correctly order the module based on inputs and outputs, detects cycle,
+ * and much more.
+ *
+ * \param description Description of the relationship between the modules.
+ * \param[in, out] modules Vector of modules contributing to the graph. This vector will be sorted and cleaned of un-used modules
+ * \param on_module_removed A call-back called each time a module is removed from the graph. Call back signature `void (const std::string&);`
+ *
+ * \sa Pool::description()
+ */
+Graph build(const Pool::DescriptionMap& description, std::vector<ModulePtr>& modules, std::function<void(const std::string&)> on_module_removed);
+
+/**
+ * \brief Export a given graph in `dot` format
+ *
+ * \note To produce a PDF, run the following command
+ * ```
+ * dot -Tpdf filename.dot -o filename.pdf
+ * ```
+ *
+ * \param g The graph to export
+ * \param filename The output filename
+ */
+void graphviz_export(const Graph& g, const std::string& filename);
+
+}

--- a/core/src/Graph.cc
+++ b/core/src/Graph.cc
@@ -1,0 +1,157 @@
+#include <Graph.h>
+#include <logging.h>
+
+#include <momemta/Module.h>
+
+#include <boost/graph/graphviz.hpp>
+#include <boost/graph/topological_sort.hpp>
+
+namespace graph {
+
+class unresolved_input: public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
+Graph build(const Pool::DescriptionMap& description, std::vector<ModulePtr>& modules, std::function<void(const std::string&)> on_module_removed) {
+
+    Graph g;
+
+    uint32_t id = 0;
+    std::unordered_map<std::string, vertex_t> vertices;
+
+    // Create vertices. Each vertex is a module
+    for (const auto& d: description) {
+        vertex_t v = boost::add_vertex(g);
+        vertices.emplace(d.first, v);
+
+        g[v].name = d.first;
+        g[v].id = id;
+        auto module = std::find_if(modules.begin(), modules.end(), [&d](const ModulePtr& m) { return m->name() == d.first; });
+        if (module != modules.end())
+            g[v].module = *module;
+        id++;
+    }
+
+    modules.clear();
+
+    // Create edges. One edge connect one module output to one module input
+    for (const auto& vertex: vertices) {
+        const auto& outputs = description.at(vertex.first).outputs;
+
+        // Find all modules having for input this output
+        for (const auto& output: outputs) {
+
+            for (const auto& module: description) {
+                // Skip ourself
+                if (module.first == vertex.first)
+                    continue;
+
+                for (const auto& input: module.second.inputs) {
+                    if ((input.module == vertex.first) && (input.parameter == output)) {
+                        edge_t e;
+                        bool inserted;
+                        std::tie(e, inserted) = boost::add_edge(vertex.second, vertices.at(module.first), g);
+                        g[e].name = input.parameter;
+                        if (input.isIndexed()) {
+                            g[e].name += "[" + std::to_string(input.index) + "]";
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Find any module whose output is not used by any module. It's useless, so remove it
+    // Only allowed module in this situation is virtual modules.
+    for (auto it = vertices.begin(), ite = vertices.end(); it != ite;) {
+        if (boost::out_degree(it->second, g) == 0) {
+
+            if (Module::is_virtual_module(it->first)) {
+                ++it;
+                continue;
+            }
+
+            on_module_removed(it->first);
+            LOGGER->info("Module '{}' output is not used by any other module. Removing it from the configuration.", it->first);
+            boost::clear_vertex(it->second, g);
+            boost::remove_vertex(it->second, g);
+            it = vertices.erase(it);
+        } else
+            ++it;
+    }
+
+    auto log_and_throw_unresolved_input = [](const std::string& module_name, const InputTag& input) {
+        LOGGER->critical("Module '{}' requested a non-existing input ({})", module_name, input.toString());
+        throw unresolved_input("Module '" + module_name + "' requested a non-existing input (" + input.toString() + ")");
+    };
+
+    // Find any module whose input point to a non-existing module / parameter
+    for (const auto& vertex: vertices) {
+        const auto& inputs = description.at(vertex.first).inputs;
+
+        for (const auto& input: inputs) {
+            auto it = vertices.find(input.module);
+            if (it == vertices.end()) {
+                // Non-existing module
+                log_and_throw_unresolved_input(vertex.first, input);
+            }
+
+            // Look for input in module's output
+            const auto& target_module_output = description.at(it->first).outputs;
+            auto it_input = std::find_if(target_module_output.begin(), target_module_output.end(), [&input](const std::string& output) {
+                    return input.parameter == output;
+                    });
+
+            if (it_input == target_module_output.end()) {
+                // Non-existing parameter
+                log_and_throw_unresolved_input(vertex.first, input);
+            }
+        }
+    }
+
+    // Re-assign each vertex a continuous id
+    id = 0;
+    typename boost::graph_traits<Graph>::vertex_iterator it_i, it_end;
+    for (std::tie(it_i, it_end) = boost::vertices(g); it_i != it_end; it_i++) {
+        g[*it_i].id = id++;
+    }
+
+    // Sort graph
+    std::list<vertex_t> sorted_vertices;
+    boost::topological_sort(g, std::front_inserter(sorted_vertices), boost::vertex_index_map(boost::get(&graph::Vertex::id, g)));
+
+    // Remove virtual vertices
+    sorted_vertices.erase(std::remove_if(sorted_vertices.begin(), sorted_vertices.end(),
+                [&g](const vertex_t& vertex) {
+                    return Module::is_virtual_module(g[vertex].name);
+                }), sorted_vertices.end());
+
+    // Re-fill modules vector with new content (sorted & cleaned)
+    for (const auto& vertex: sorted_vertices) {
+        modules.push_back(g[vertex].module);
+    }
+
+    return g;
+}
+
+class edge_writer {
+    public:
+        edge_writer(Graph g) : graph(g) {}
+        template <class VertexOrEdge>
+            void operator()(std::ostream& out, const VertexOrEdge& v) const {
+                out << "[label=\"" << graph[v].name << "\"]";
+            }
+    private:
+        Graph graph;
+};
+
+void graphviz_export(const Graph& g, const std::string& filename) {
+
+    std::ofstream f(filename.c_str());
+
+    auto vertices_name = boost::get(&Vertex::name, g);
+    auto edges_name = boost::get(&Edge::name, g);
+
+    boost::write_graphviz(f, g, make_label_writer(vertices_name), make_label_writer(edges_name), boost::default_writer(), boost::get(&Vertex::id, g));
+}
+}

--- a/core/src/MoMEMta.cc
+++ b/core/src/MoMEMta.cc
@@ -25,7 +25,9 @@
 #include <momemta/MoMEMta.h>
 #include <momemta/Utils.h>
 
+#include <Graph.h>
 #include <logging.h>
+
 
 MoMEMta::MoMEMta(const ConfigurationReader& configuration) {
     
@@ -41,8 +43,8 @@ MoMEMta::MoMEMta(const ConfigurationReader& configuration) {
     m_particles = m_pool->put<std::vector<LorentzVector>>({"input", "particles"});
 
     // Construct modules from configuration
-    std::vector<LightModule> modules = configuration.getModules();
-    for (const auto& module: modules) {
+    std::vector<LightModule> light_modules = configuration.getModules();
+    for (const auto& module: light_modules) {
         m_pool->current_module(module.name);
         m_modules.push_back(ModuleFactory::get().create(module.type, m_pool, *module.parameters));
         m_modules.back()->configure();
@@ -62,9 +64,20 @@ MoMEMta::MoMEMta(const ConfigurationReader& configuration) {
     m_pool->current_module("momemta");
     m_weights = m_pool->get<std::vector<double>>({m_modules.back()->name(), "weights"});
 
-    m_pool->freeze();
-
     m_vegas_configuration = configuration.getVegasConfiguration();
+
+    const Pool::DescriptionMap& description = m_pool->description();
+    graph::build(description, m_modules, [&description, this](const std::string& module) {
+                // Clean the pool for each removed module
+                const Description& d = description.at(module);
+                for (const auto& input: d.inputs)
+                    this->m_pool->remove_if_invalid(input);
+                for (const auto& output: d.outputs)
+                    this->m_pool->remove({module, output});
+            });
+
+    // Freeze the pool after removing unneeded modules
+    m_pool->freeze();
 
     cubacores(0, 0);
 }

--- a/include/momemta/Module.h
+++ b/include/momemta/Module.h
@@ -21,6 +21,7 @@
 
 #include <momemta/ModuleFactory.h>
 #include <momemta/Pool.h>
+#include <momemta/InputTag.h>
 
 class Module {
     public:
@@ -39,6 +40,18 @@ class Module {
 
         virtual std::string name() const final {
             return m_name;
+        }
+
+        /**
+         * \brief Test if a given name correspond to a virtual module
+         *
+         * Some names are reserved for internal usage and are mapped to virtual modules.
+         *
+         * \param name The name to test
+         * \return True if `name` is the name of a virtual module, false otherwise.
+         */
+        inline static bool is_virtual_module(const std::string& name) {
+            return (name == "momemta") || (name == "input") || (name == "cuba");
         }
 
     protected:

--- a/include/momemta/impl/InputTag.h
+++ b/include/momemta/impl/InputTag.h
@@ -16,8 +16,25 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
-#include <momemta/impl/InputTag_fwd.h>
-#include <momemta/impl/InputTag.h>
+#include <momemta/Pool.h>
+
+template<typename T> const T& InputTag::get() const {
+    if (! resolved) {
+        throw tag_not_resolved_error("You must call 'resolve' once before calling 'get'");
+    }
+
+    if (content.empty()) {
+        // Request the real content to the pool
+        content = pool->raw_get(*this);
+    }
+
+    if (isIndexed()) {
+        auto ptr = boost::any_cast<std::shared_ptr<std::vector<T>>>(content);
+        return (*ptr)[index];
+    } else {
+        auto ptr = boost::any_cast<std::shared_ptr<T>>(content);
+        return (*ptr);
+    }
+}

--- a/include/momemta/impl/InputTag_fwd.h
+++ b/include/momemta/impl/InputTag_fwd.h
@@ -1,0 +1,95 @@
+/*
+ *  MoMEMta: a modular implementation of the Matrix Element Method
+ *  Copyright (C) 2016  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include <boost/any.hpp>
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <momemta/Utils.h>
+
+class Pool;
+
+struct InputTag {
+    public:
+        InputTag(const std::string& module, const std::string& parameter);
+        InputTag(const std::string& module, const std::string& parameter, size_t index);
+        InputTag() = default;
+
+        /*!
+         *  Check if a given string is an input tag. Expected format is
+         *      Module::Parameter[/Index]
+         *
+         *  Delimiter is '::'.
+         */
+        static bool isInputTag(const std::string& tag);
+
+        /*!
+         * Create a input tag from a string. No check is performed to ensure that
+         * the string is an input tag. Use `isInputTag` first.
+         */
+        static InputTag fromString(const std::string& tag);
+
+        bool operator==(const InputTag& rhs) const;
+
+        std::string toString() const;
+
+        bool isIndexed() const;
+
+        /**
+         * \brief Link the InputTag to the memory pool
+         *
+         * \note You **must** call this function before calling InputTag::get()
+         */
+        void resolve(std::shared_ptr<Pool> pool) const;
+
+        template<typename T> const T& get() const;
+
+        std::string module;
+        std::string parameter;
+        size_t index;
+
+    private:
+        class tag_not_resolved_error: public std::runtime_error {
+            using std::runtime_error::runtime_error;
+        };
+
+        bool indexed = false;
+
+        std::string string_representation;
+
+        mutable bool resolved = false;
+        mutable boost::any content;
+        mutable std::shared_ptr<Pool> pool;
+};
+
+namespace std {
+    template<>
+        struct hash<InputTag> {
+            size_t operator()(const InputTag& tag) const {
+                return string_hash(tag.module) + string_hash(tag.parameter);
+            }
+
+            std::hash<std::string> string_hash;
+        };
+}

--- a/modules/MatrixElement.cc
+++ b/modules/MatrixElement.cc
@@ -88,6 +88,8 @@ class MatrixElement: public Module {
             m_ME = MatrixElementFactory::get().create(matrix_element, matrix_element_configuration);
 
             // PDF
+            // Silence LHAPDF
+            LHAPDF::setVerbosity(0);
             std::string pdf = parameters.get<std::string>("pdf");
             m_pdf.reset(LHAPDF::mkPDF(pdf, 0));
 


### PR DESCRIPTION
The graph also us to quickly:
 - detect non-existing inputs
 - remove modules with non-used outputs
 - detect cyclic dependencies (currently not done, but can be easily added)
 - order module execution based on which depend on what