### PR TITLE
Update doxygen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ addons:
       - g++-4.9
       - cmake
       - libboost1.55-dev
-      - doxygen
       - graphviz
 before_install:
   - ./travis/decrypt_key.sh 
@@ -27,6 +26,7 @@ install:
   - export CC=gcc-4.9
   - source travis/get-root.sh
   - source travis/get-lhapdf.sh
+  - source travis/get-doxygen.sh
 before_script:
   - export CXX=g++-4.9
   - export CC=gcc-4.9

--- a/docs/theme/Doxyfile.in
+++ b/docs/theme/Doxyfile.in
@@ -827,7 +827,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */external/*
+EXCLUDE_PATTERNS       = */external/* *@CMAKE_CURRENT_BINARY_DIR@/* */MatrixElements/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/docs/theme/Doxyfile.in
+++ b/docs/theme/Doxyfile.in
@@ -933,7 +933,7 @@ USE_MDFILE_AS_MAINPAGE = README.md
 # also VERBATIM_HEADERS is set to NO.
 # The default value is: NO.
 
-SOURCE_BROWSER         = NO
+SOURCE_BROWSER         = YES
 
 # Setting the INLINE_SOURCES tag to YES will include the body of functions,
 # classes and enums directly into the documentation.

--- a/docs/theme/customdoxygen.css
+++ b/docs/theme/customdoxygen.css
@@ -362,3 +362,30 @@ span.SRScope {
 .pull-right .label {
    margin: 0px 0 0 2px;
 }
+
+:not(pre) > code.hljs {
+    display: inline;
+    vertical-align: bottom;
+}
+
+pre.code {
+    display: block;
+    padding: 0;
+    margin: 0;
+    border: 0;
+}
+
+pre {
+    counter-reset: lines;
+}
+
+pre .line {
+    counter-increment: lines;
+}
+
+pre .line::before {
+    content: counter(lines); text-align: right;
+    display: inline-block; width: 3em;
+    padding-right: 0.5em; margin-right: 0.5em;
+    color: #839496; border-right: 1px solid #e0e0e0 !important;
+}

--- a/docs/theme/doxy-boot.js
+++ b/docs/theme/doxy-boot.js
@@ -1,4 +1,11 @@
+hljs.configure({
+  tabReplace: '    ',
+  languages: ['cpp']
+});
+
 $(document).ready(function() {
+
+    $(".fragment").hide();
 
     $("div.headertitle").addClass("page-header");
     $("div.title").addClass("h1");
@@ -43,7 +50,7 @@ $(document).ready(function() {
     $("table.directory").addClass("table table-striped");
     $("div.summary > a").addClass("btn btn-default btn-xs");
     $("table.fieldtable").addClass("table");
-    $(".fragment").addClass("well");
+    //$(".fragment").addClass("well");
     $(".memitem").addClass("panel panel-default");
     $(".memproto").addClass("panel-heading");
     $(".memdoc").addClass("panel-body");
@@ -62,8 +69,8 @@ $(document).ready(function() {
     $("div.ttname a").css("color", 'white');
     $("div.ttdef,div.ttdoc,div.ttdeci").addClass("panel-body");
 
-    $('div.fragment.well div.line:first').css('margin-top', '15px');
-    $('div.fragment.well div.line:last').css('margin-bottom', '15px');
+    //$('div.fragment.well div.line:first').css('margin-top', '15px');
+    //$('div.fragment.well div.line:last').css('margin-bottom', '15px');
 
     $('table.doxtable').removeClass('doxtable').addClass('table table-striped table-bordered').each(function() {
         $(this).prepend('<thead></thead>');
@@ -74,9 +81,9 @@ $(document).ready(function() {
         $(this).find('td > span.danger').parent().addClass('danger');
     });
 
-    if ($('div.fragment.well div.ttc').length > 0) {
-        $('div.fragment.well div.line:first').parent().removeClass('fragment well');
-    }
+    //if ($('div.fragment.well div.ttc').length > 0) {
+        //$('div.fragment.well div.line:first').parent().removeClass('fragment well');
+    //}
 
     // $('table.memberdecls').find('.memItemRight').each(function(){
     //   $(this).contents().appendTo($(this).siblings('.memItemLeft'));
@@ -256,16 +263,45 @@ $(document).ready(function() {
     $("div.ah").removeClass('ah');
     $("div.header").removeClass("header");
 
-    // $('.mdescLeft').each(function(){
-    //   if($(this).html()=="&nbsp;") {
-    //     $(this).siblings('.mdescRight').attr('colspan', 2);
-    //     $(this).remove();
-    //   }
-    // });
-    // $('td.memItemLeft').each(function(){
-    //   if($(this).siblings('.memItemRight').html()=="") {
-    //     $(this).attr('colspan', 2);
-    //     $(this).siblings('.memItemRight').remove();
-    //   }
-    // });
+    $(".fragment").each(function(i, node) {
+        // Remove line numbers
+        lines = $(node).find('.lineno').remove();
+        have_lines = lines.length != 0;
+
+        // Build code
+        code = ''
+        $(node).find('.line').each(function(i, line) {
+          code += $(line).text() + '\n';
+        });
+        $(node).html("<pre class='code'><code></code></pre>");
+        $(node).find('code').text(code);
+
+        $(node).removeClass('fragment').addClass('highlighted-code');
+        if (have_lines) {
+            $(node).addClass('line-number');
+        }
+    });
+
+    $('code').each(function(i, block) {
+        hljs.highlightBlock(block);
+    });
+
+    function pad(str, max) {
+        str = str.toString();
+        return str.length < max ? pad("0" + str, max) : str;
+    }
+
+    $('div.line-number > pre > code').each(function(i, node) {
+
+        // Re-add line numbers
+        code = $(node).html().split('\n');
+        flat_code = '';
+        for (index = 0; index < code.length; ++index) {
+            flat_code += '<a name="l' + pad(index + 1, 5) + '" href="#"></a><span class="line"></span>' + code[index] + '\n';
+        }
+
+        $(node).html(flat_code);
+    });
+
+    $('.highlighted-code').show();
 });

--- a/docs/theme/header.html
+++ b/docs/theme/header.html
@@ -9,7 +9,10 @@
         <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
         <meta name="generator" content="Doxygen $doxygenversion"/>
 
-        <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.3/jquery.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-scrollTo/2.1.2/jquery.scrollTo.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-powertip/1.2.0/jquery.powertip.min.js"></script>
 
         <!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
         <!--BEGIN !PROJECT_NAME--><title>$title</title><!--END !PROJECT_NAME-->

--- a/docs/theme/header.html
+++ b/docs/theme/header.html
@@ -26,6 +26,8 @@
 
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/styles/solarized-light.min.css">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/highlight.min.js"></script>
         <script type="text/javascript" src="$relpath^doxy-boot.js"></script>
     </head>
     <body>

--- a/travis/get-doxygen.sh
+++ b/travis/get-doxygen.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+
+doxygen_VERSION=1.8.11
+BUNDLE=doxygen-${doxygen_VERSION}_Python-2.7_gcc-4.9.3_Ubuntu_14.04_x86_64
+
+mkdir -p external/doxygen
+cd external/doxygen
+
+wget http://sbrochet.web.cern.ch/sbrochet/public/${BUNDLE}.tar.xz
+
+tar xf ${BUNDLE}.tar.xz
+cd ${BUNDLE}
+
+export PATH="$PWD/bin:$PATH"
+export LD_LIBRARY_PATH="$PWD/lib:$LB_LIBRARY_PATH"
+
+cd ../../..

--- a/travis/get-lhapdf.sh
+++ b/travis/get-lhapdf.sh
@@ -14,8 +14,6 @@ cd ${BUNDLE}
 # Fix 'lhapdf-config' which hardcode path
 sed -i "s#/vagrant/builds/LHAPDF-6.1.6_Python-2.7_gcc-4.9.3_Ubuntu_14.04_x86_64#$PWD#" bin/lhapdf-config
 
-cat bin/lhapdf-config
-
 export PATH="$PWD/bin:$PATH"
 export LD_LIBRARY_PATH="$PWD/lib:$LB_LIBRARY_PATH"
 


### PR DESCRIPTION
Three main things:

 - Update doxygen to latest version on travis. This is done by downloading a pre-build version of doxygen 1.8.11.
 - Use `highlight.js` library to perform syntax highlighing of both inline and block source. Parsing is better than built-in doxygen one, and we can also switch theme very easily. I used [solarized light](http://ethanschoonover.com/solarized) as a first choice, but it can be changed if you guys doesn't like it.
 - Embed source code in the documentation.