### PR TITLE
NWA module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ set(MOMEMTA_SOURCES
     "modules/Flatter.cc"
     "modules/GaussianTransferFunction.cc"
     "modules/BinnedTransferFunctionOnEnergy.cc"
+    "modules/NarrowWidthApproximation.cc"
     "modules/MatrixElement.cc"
     "modules/Permutator.cc"
     "core/src/ConfigurationReader.cc"
@@ -147,10 +148,16 @@ target_link_libraries(momemta LINK_PRIVATE "-Wl,--whole-archive $<TARGET_FILE:me
 
 add_library(empty_module SHARED "modules/EmptyModule.cc")
 
+# Example executables
 add_executable(example_tt_fullyleptonic "examples/tt_fullyleptonic.cc")
 target_link_libraries(example_tt_fullyleptonic momemta)
 set_target_properties(example_tt_fullyleptonic PROPERTIES OUTPUT_NAME
   "tt_fullyleptonic.exe")
+
+add_executable(example_tt_fullyleptonic_NWA "examples/tt_fullyleptonic_NWA.cc")
+target_link_libraries(example_tt_fullyleptonic_NWA momemta)
+set_target_properties(example_tt_fullyleptonic_NWA PROPERTIES OUTPUT_NAME
+  "tt_fullyleptonic_NWA.exe")
 
 # Install targets
 

--- a/examples/tt_fullyleptonic_NWA.cc
+++ b/examples/tt_fullyleptonic_NWA.cc
@@ -1,0 +1,59 @@
+/*
+ *  MoMEMta: a modular implementation of the Matrix Element Method
+ *  Copyright (C) 2016  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <momemta/MoMEMta.h>
+#include <momemta/Utils.h>
+
+#include <chrono>
+
+using namespace std::chrono;
+
+int main(int argc, char** argv) {
+
+    UNUSED(argc);
+    UNUSED(argv);
+
+    spdlog::set_level(spdlog::level::trace);
+
+    ConfigurationReader configuration("../examples/tt_fullyleptonic_NWA.lua");
+    MoMEMta weight(configuration);
+
+    // Electron
+    LorentzVector p3(16.171895980835, -13.7919054031372, -3.42997527122497, 21.5293197631836);
+    // b-quark
+    LorentzVector p4(-55.7908325195313, -111.59294128418, -122.144721984863, 174.66259765625);
+    // Muon
+    LorentzVector p5(-18.9018573760986, 10.0896110534668, -0.602926552295686, 21.4346446990967);
+    // Anti b-quark
+    LorentzVector p6(71.3899612426758, 96.0094833374023, -77.2513122558594, 142.492813110352);
+
+    auto start_time = system_clock::now();
+    std::vector<std::pair<double, double>> weights = weight.computeWeights({p3, p4, p5, p6});
+    auto end_time = system_clock::now();
+
+    LOG(debug) << "Result:";
+    for (const auto& r: weights) {
+        LOG(debug) << r.first << " +- " << r.second;
+    }
+
+    LOG(info) << "Weight computed in " << std::chrono::duration_cast<milliseconds>(end_time - start_time).count() << "ms";
+
+
+    return 0;
+}

--- a/examples/tt_fullyleptonic_NWA.lua
+++ b/examples/tt_fullyleptonic_NWA.lua
@@ -1,0 +1,159 @@
+M_W = 80.419002
+M_TOP = 173.
+W_W = 2.047600e+00
+W_TOP = 1.491500e+00
+
+-- Use transfer functions
+inputs_before_perm = {
+    'tf_p1::output',
+    'tf_p2::output',
+    'tf_p3::output',
+    'tf_p4::output',
+}
+
+-- Use permutator module to permutate input particles 0 and 2 using the MC
+inputs = {
+  inputs_before_perm[1],
+  'permutator::output/0',
+  inputs_before_perm[3],
+  'permutator::output/1',
+}
+
+configuration = {
+    energy = 13000.,
+    top_mass = M_TOP,
+    W_mass = M_W
+}
+
+vegas = {
+    verbosity = 3
+}
+
+-- Use the narrow width approximation for both Top & W propagators
+NarrowWidthApproximation.nwa_s13 = {
+    mass = M_W,
+    width = W_W
+}
+
+NarrowWidthApproximation.nwa_s134 = {
+    mass = M_TOP,
+    width = W_TOP
+}
+
+NarrowWidthApproximation.nwa_s25 = {
+    mass = M_W,
+    width = W_W
+}
+
+NarrowWidthApproximation.nwa_s256 = {
+    mass = M_TOP,
+    width = W_TOP
+}
+
+GaussianTransferFunction.tf_p1 = {
+    ps_point = 'cuba::ps_points/0',
+    reco_particle = 'input::particles/0',
+    sigma = 0.05,
+}
+
+GaussianTransferFunction.tf_p2 = {
+    ps_point = 'cuba::ps_points/1',
+    reco_particle = 'input::particles/1',
+    sigma = 0.10,
+}
+
+GaussianTransferFunction.tf_p3 = {
+    ps_point = 'cuba::ps_points/2',
+    reco_particle = 'input::particles/2',
+    sigma = 0.05,
+}
+
+GaussianTransferFunction.tf_p4 = {
+    ps_point = 'cuba::ps_points/3',
+    reco_particle = 'input::particles/3',
+    sigma = 0.10,
+}
+  
+Permutator.permutator = {
+    ps_point = 'cuba::ps_points/4',
+    input = {
+      inputs_before_perm[2],
+      inputs_before_perm[4],
+    }
+}
+
+BlockD.blockd = {
+    inputs = inputs,
+
+    s13 = 'nwa_s13::s',
+    s134 = 'nwa_s134::s',
+    s25 = 'nwa_s25::s',
+    s256 = 'nwa_s256::s',
+}
+
+Boost.boost = {
+    invisibles = {
+        'blockd::invisibles',
+    },
+
+    particles = inputs
+}
+
+
+jacobians = {
+  'nwa_s13::jacobian', 'nwa_s134::jacobian', 'nwa_s25::jacobian', 'nwa_s256::jacobian', 
+}
+
+MatrixElement.ttbar = {
+  pdf = 'CT10nlo',
+
+  matrix_element = 'pp_ttx_fully_leptonic',
+  matrix_element_parameters = {
+      card = '../MatrixElements/Cards/param_card.dat'
+  },
+
+  initialState = 'boost::output',
+
+  invisibles = {
+    input = 'blockd::invisibles',
+    jacobians = 'blockd::jacobians',
+    ids = {
+      {
+        pdg_id = 12,
+        me_index = 2,
+      },
+
+      {
+        pdg_id = -14,
+        me_index = 5,
+      }
+    }
+  },
+
+  particles = {
+    inputs = inputs,
+    ids = {
+      {
+        pdg_id = -11,
+        me_index = 1,
+      },
+
+      {
+        pdg_id = 5,
+        me_index = 3,
+      },
+
+      {
+        pdg_id = 13,
+        me_index = 4,
+      },
+
+      {
+        pdg_id = -5,
+        me_index = 6,
+      },
+    }
+  },
+
+  jacobians = jacobians
+}

--- a/modules/BinnedTransferFunctionOnEnergy.cc
+++ b/modules/BinnedTransferFunctionOnEnergy.cc
@@ -27,7 +27,7 @@
 #include <TH2.h>
 #include <TAxis.h>
 
-/** Transfer function on energy described by a 2D histogram retrieved from a ROOT file.
+/** \brief Transfer function on energy described by a 2D histogram retrieved from a ROOT file.
  * 
  * This module takes as input a LorentzVector and a phase-space point, generates
  * a new LorentzVector with a different energy (keeping direction and invariant mass),

--- a/modules/NarrowWidthApproximation.cc
+++ b/modules/NarrowWidthApproximation.cc
@@ -1,0 +1,85 @@
+/*
+ *  MoMEMta: a modular implementation of the Matrix Element Method
+ *  Copyright (C) 2016  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** \brief Use the Narrow Width Approximation (NWA) to reduce the dimensionality of the integration.
+ *
+ *  It is possible to reduce the number of integrated dimensions by fixing the mass of one of the propagators
+ *  one is integrating over to the observed mass of the corresponding particle. 
+ *  This approximation is exact in the limit \f$\Gamma/m \to 0\f$.
+ *
+ *  To implement this approximation in MoMEMta, you need to change the way the Block is fed the `s` (propagator mass squared) variable: 
+ *  Instead of retrieving it from the `Flatter` module (which adds a dimension to carry out integration over
+ *  the propagator mass), use this module's output as input to the Block.
+ *
+ *  This module defines a 'jacobian' factor, important for the normalisation of the likelihood. Formally, the NWA is defined by
+ *  replacing, in the matrix element, a propagator by a Diract delta function:
+ *  \f$\int ds |\mathcal{M}|^2 = \int ds \frac{|\mathcal{M}_d|^2}{(s-m^2)^2+(m \Gamma)^2} \to \frac{\pi}{m \Gamma} \int ds \delta(s-m^2) |\mathcal{M}_d|^2 \f$
+ *  where \f$\mathcal{M}_d\f$ is the rest of the matrix element (without the propagator), and where the factor \f$\frac{\pi}{m\Gamma}\f$ is needed because of the normalisation of the Dirac delta:
+ *  \f$\int_{-\infty}{+\infty} ds \delta(s) = 1\f$, but \f$ \int_{-\infty}{+\infty} ds \frac{1}{(s-m^2)^2+(m \Gamma)^2} = \frac{\pi}{m\Gamma}\f$.
+ *
+ *  However, in most of the cases, the matrix element used by the user still includes the propagator (ie, what is used is \f$\mathcal{M}\f$, not \f$\mathcal{M}_d\f$. The propagator
+ *  evaluated on \f$s=m^2\f$ is just \f$(m\Gamma)^{-2}\f$, so that the normalisation factor to use is \f$\pi m \Gamma\f$.
+ *
+ *  This module handles both cases, which can be configured through the `propagator_in_me` parameter.
+ *
+ *  - Integration dimension: 0
+ *
+ *  - Parameters:
+ *    - `mass` (double): Mass of the propagator one wishes to fix. 
+ *    - `width` (double): Width of the corresponding particle.
+ *    - `propagator_in_me` (bool): Whether the propagator is included in the matrix element or not.
+ *
+ *  - Inputs: None
+ *
+ *  - Outputs:
+ *    - `s` (double): Just \f$s=\text{mass}^2\f$, to be passed to the Block.
+ *    - `jacobian` (double): Overall factor for proper normalisation.
+ */
+
+#include <momemta/ConfigurationSet.h>
+#include <momemta/Module.h>
+
+class NarrowWidthApproximation: public Module {
+    public:
+
+        NarrowWidthApproximation(PoolPtr pool, const ConfigurationSet& parameters): Module(pool, parameters.getModuleName())
+        {
+            double mass = parameters.get<double>("mass");
+            double width = parameters.get<double>("width");
+
+            *jacobian = M_PI;
+            if(parameters.get<bool>("propagator_in_me", true))
+                *jacobian *= mass*width; 
+            else
+                *jacobian /= mass*width; 
+            
+            *s = mass*mass; 
+        }
+
+        virtual void work() override {}
+
+        virtual size_t dimensions() const override {
+            return 0;
+        }
+
+    private:
+        
+        std::shared_ptr<double> s = produce<double>("s");
+        std::shared_ptr<double> jacobian = produce<double>("jacobian");
+};
+REGISTER_MODULE(NarrowWidthApproximation);


### PR DESCRIPTION
Add a module to handle the narrow width approximation for a propagator one does not want to integrate over.

In practice the blocks are used the same way, but one replaces a `Flatter` module by a `NarrowWidthApproximation` module as input for a block's `s` invariant.

Added a minimal working example to demonstrate the use of this module without cloggering the other example.

Note: works, but not validated physics-wise (as all the rest).