### PR TITLE
Fixed typos in docs

### DIFF
--- a/docs/BlockB.md
+++ b/docs/BlockB.md
@@ -1,6 +1,6 @@
 # Block B description
 Note: Block B, also referred as final block (FB), and class in the MadWeight world. 
-Description inspired on MadWeight.
+Description inspired by MadWeight.
 
 This block corresponds to an initial state with Bjorken fractions \f$q_1\f$ and \f$q_2\f$, 
 and a final state with a visible particle with momenta \f$p_2\f$, and an invisible particle 
@@ -16,16 +16,22 @@ in CUBA, this Block outputs the value of the jacobian, J, and the four momenta o
 
 From the standard phase-space parametrisation:
 
-\f$dq_1 dq_2\frac{d^3 p_1}{(2\pi)^3 2E_1}(2\pi)^4 \delta^4 (P_{in}-P_{fin})\f$
+\f[
+  dq_1 dq_2\frac{d^3 p_1}{(2\pi)^3 2E_1}(2\pi)^4 \delta^4 (P_{in}-P_{out})
+\f]
 
-where \f$P_{in} and P_{fin)\f$ are the total four-momenta in the initial and final states, to the 
+where \f$P_{in} and P_{out}\f$ are the total four-momenta in the initial and final states, to the 
 following parametrisation: 
 
-\f$\frac{1}{4\pi E_1} ds_{12} \times J\f$
+\f[
+  \frac{1}{4\pi E_1} ds_{12} \times J
+\f]
 
 where the jacobian, J, is given by:
 
-\f$J = \frac{E_1}{s} |p_{2z} E_1 -  E_2 p_{1z}|^{-1}\f$
+\f[
+  J = \frac{E_1}{s} \left| p_{2z} E_1 -  E_2 p_{1z} \right|^{-1}
+\f]
 
 ### Parameters
 
@@ -33,32 +39,33 @@ where the jacobian, J, is given by:
 
 ### Inputs
 
-- Visible particle, with four momenta \f$p_2\f$
-- The mass \f$s_{12}\f$ as output from the Flatter module.
+- Visible particle, with 4-momentum \f$p_2\f$
+- The invariant \f$s_{12}\f$ as output from the Flatter or NarrowWidthApproximation module.
 
 ### Outputs
 
-- Invisible particle, with four momenta \f$p_1\f$ (up to two solutions possible)
+- Invisible particle, with 4-momentum \f$p_1\f$ (up to two solutions possible)
 - Jacobian, one per solution.    
 
 ### System of equations to compute \f$p_1\f$
 
-The integrator throws random points in the mass (\f$s_{12}\f$) while \f$p_2\f$ is a known quantity. The equations to 
+The integrator throws random points in the invariant (\f$s_{12}\f$) while \f$p_2\f$ is a known quantity. The equations to 
 compute \f$p_1\f$ are:
 
- 1. \f$(p_1 + p_2)^2 = s_{12} = M_{1}^{2} + M_{2}^2 + 2 E_1 E_2 + 2 p_{1x}p_{2x} + 2p_{1y}p_{2y} + p_{1z}p_{2z}\f$
- 2. \f$p_{1x} = - p_{Tx}\f$ #Coming from \f$p_{T}^{\nu} = -p_{T}^{visible} = - (p_2 + ISR)\f$
- 3. \f$p_{1y} = - p_{Ty}\f$ #Coming from \f$p_{T}^{\nu} = -p_{T}^{visible} = - (p_1 + ISR)\f$
- 4. \f$M_1 = 0 \to E_{1}^2 = p_{1x}^2 + p_{1y}^2 + p_{1z}^2\f$
+\f{eqnarray}{
+ s_{12} &=& (p_1 + p_2)^2 = M_{1}^{2} + M_{2}^2 + 2 E_1 E_2 + 2 p_{1x}p_{2x} + 2p_{1y}p_{2y} + p_{1z}p_{2z}
+ p_{1x} &=& - p_{Tx}
+ p_{1y} &=& - p_{Ty}
+ p_1^2 &=& 0 \Leftrightarrow E_{1}^2 = p_{1x}^2 + p_{1y}^2 + p_{1z}^2
+\f}
 
-Using the values of \f$p_{1x}, p_{1y}\f$ from equations (2) and (3), equation (1) can be written as \f$p_{1z} = A - B E_1\f$. Where A and B are:
+Where \f$\vec{p}_T\f$ is the total transverse momentum of the visible particles. Using the values of \f$p_{1x}, p_{1y}\f$ from equations (2) and (3), equation (1) can be written as \f$p_{1z} = A - B E_1\f$, where A and B are:
+\f{eqnarray}{
+ A &=& \frac{s_{12} - M_{2}^2 + 2(p_{Tx}p_{2x} + p_{Ty}p_{2y})}{2 p_{2z}}
+ B &=& \frac{E_2}{p_{2z}}
+\f}
 
-- \f$A = \frac{s_{12} - M_{2}^2 + 2(p_{Tx}p_{2x} + p_{Ty}p_{2y})}{2 p_{2z}}\f$
-- \f$B = \frac{E_2}{p_{2z}}\f$
+Finally equation (4) can be written as \f$(1 - B) E_{1}^2 + 2AB E_1 - C = 0\f$, where \f$C = p_{Tx}^{2} + p_{Ty}^{2}\f$.
 
-Finally equation (4) can be written as: 
-
-- \f$(1 - B) E_{1}^2 + 2AB E_1 - C = 0\f$, where \f$C = p_{Tx}^{2} + p_{Ty}^{2}\f$
-
-Each solution of the quadratic equation with a positive value of $$E_1\f$ is taken.
+Each solution of the quadratic equation with a positive value of \f$E_1\f$ is taken.
 

--- a/modules/BlockB.cc
+++ b/modules/BlockB.cc
@@ -24,31 +24,32 @@
 
 
 /** Final (main) Block B, consisting on \f$q_1 q_2 \to X + s_{12} \to X + p_1 p_2\f$,  
- * where \f$q_1\f$ and \f$q_2\f$ are Bjorken fractions, and s_{12} is a particle decaying 
+ * where \f$q_1\f$ and \f$q_2\f$ are Bjorken fractions, and \f$s_{12}\f$ is a particle decaying 
  * into \f$p_1\f$ (invisible particle) and \f$p_2\f$ (visible particle).
  *
  * This Block addresses the change of variables needed to pass from the standard phase-space
- * parametrization to the \f$\frac{1}{4\pi E_1} ds_{12} \times J\f$ parametrization.               .
+ * parametrization to the \f$\frac{1}{4\pi E_1} ds_{12} \times J\f$ parametrization.
  * 
  * The integration is performed over \f$s_{12}\f$ with \f$p_2\f$ as input. Per integration point, 
  * the LorentzVector of the invisible particle, \f$p_1\f$, is computed based on the following set 
  * of equations:   
  *
  * - \f$(p_1 + p_2)^2 = s_{12} = M_{1}^{2} + M_{2}^2 + 2 E_1 E_2 + 2 p_{1x}p_{2x} + 2p_{1y}p_{2y} + p_{1z}p_{2z}\f$
- * - \f$p_{1x} = - p_{Tx}\f$ #Coming from \f$p_T\f$ neutrino \f$= -p_T\f$ visible = - (\f$p_2\f$ + ISR)
- * - \f$p_{1y} = - p_{Ty}\f$ #Coming from \f$p_T\f$ neutrino \f$= -p_T\f$ visible = - (\f$p_1\f$ + ISR)
+ * - Conservation of momentum (with \f$\vec{p}_T\f$ the total transverse momentum of visible particles):
+ *  - \f$p_{1x} = - p_{Tx}\f$
+ *  - \f$p_{1y} = - p_{Ty}\f$
  * - \f$M_1 = 0 \to E_{1}^2 = p_{1x}^2 + p_{1y}^2 + p_{1z}^2\f$
  *
- * Up to 2 \f$p_1\f$ solutions are possible.
+ * Up to two \f$p_1\f$ solutions are possible.
  *
  * - Integration dimension: 0
  *
  * - Parameters:
  *  - `energy` (double): Collision energy.
  *
- *  - Inputs:
+ * - Inputs:
  *  - `s12` (double): Invariant mass of the particle decaying into the missing particle (\f$p_1\f$) 
- *                    and the visible particle, \f$p_2\f$. Tipically coming from a Flatter module.
+ *                    and the visible particle, \f$p_2\f$. Typically coming from a Flatter module.
  *  - `inputs` (vector(LorentzVector)): LorentzVector of all the experimentally reconstructed particles.
  *                                      In this Block there is only one visible particle, \f$p_2\f$.
  * - Outputs:

--- a/modules/NarrowWidthApproximation.cc
+++ b/modules/NarrowWidthApproximation.cc
@@ -28,12 +28,15 @@
  *
  *  This module defines a 'jacobian' factor, important for the normalisation of the likelihood. Formally, the NWA is defined by
  *  replacing, in the matrix element, a propagator by a Diract delta function:
- *  \f$\int ds |\mathcal{M}|^2 = \int ds \frac{|\mathcal{M}_d|^2}{(s-m^2)^2+(m \Gamma)^2} \to \frac{\pi}{m \Gamma} \int ds \delta(s-m^2) |\mathcal{M}_d|^2 \f$
- *  where \f$\mathcal{M}_d\f$ is the rest of the matrix element (without the propagator), and where the factor \f$\frac{\pi}{m\Gamma}\f$ is needed because of the normalisation of the Dirac delta:
- *  \f$\int_{-\infty}{+\infty} ds \delta(s) = 1\f$, but \f$ \int_{-\infty}{+\infty} ds \frac{1}{(s-m^2)^2+(m \Gamma)^2} = \frac{\pi}{m\Gamma}\f$.
+ *  \f[
+ *    \int \! ds \, |\mathcal{M}|^2 = \int \! ds \, \frac{|\mathcal{M}_d|^2}{(s-m^2)^2+(m \Gamma)^2} \to \frac{\pi}{m \Gamma} \int \! ds \, \delta(s-m^2) |\mathcal{M}_d|^2
+ *  \f]
+ *  where \f$|\mathcal{M}_d|^2\f$ is the matrix element excluding the propagator, and where the factor \f$\pi/(m\Gamma)\f$ is needed because of the normalisation of the Dirac delta:
+ *  
+ *  \f$\int_{-\infty}^{+\infty} \! ds \, \delta(s) = 1\f$, but \f$ \int_{-\infty}^{+\infty} \! ds \, \frac{1}{(s-m^2)^2+(m \Gamma)^2} = \frac{\pi}{m\Gamma}\f$.
  *
- *  However, in most of the cases, the matrix element used by the user still includes the propagator (ie, what is used is \f$\mathcal{M}\f$, not \f$\mathcal{M}_d\f$. The propagator
- *  evaluated on \f$s=m^2\f$ is just \f$(m\Gamma)^{-2}\f$, so that the normalisation factor to use is \f$\pi m \Gamma\f$.
+ *  However, in most of the cases, the matrix element used by the user still includes the propagator (ie, what is used is \f$\mathcal{M}\f$, not \f$\mathcal{M}_d\f$). The propagator
+ *  evaluated on \f$s=m^2\f$ is just \f$(m\Gamma)^{-2}\f$, so that the normalisation factor becomes \f$\pi m \Gamma\f$.
  *
  *  This module handles both cases, which can be configured through the `propagator_in_me` parameter.
  *
@@ -42,7 +45,7 @@
  *  - Parameters:
  *    - `mass` (double): Mass of the propagator one wishes to fix. 
  *    - `width` (double): Width of the corresponding particle.
- *    - `propagator_in_me` (bool): Whether the propagator is included in the matrix element or not.
+ *    - `propagator_in_me` (bool, default: `true`): Whether the propagator is included in the matrix element or not.
  *
  *  - Inputs: None
  *


### PR DESCRIPTION
Fixed a couple of issues with Latex, and experiment the non-inline styles for equations: \f[ ... \f] and \f{eqnarray}{ ... }.