### PR TITLE
 Add support for delayed lua evaluation and configuration edition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set(MOMEMTA_SOURCES
     "modules/NarrowWidthApproximation.cc"
     "modules/Permutator.cc"
     "modules/UniformGenerator.cc"
+    "core/src/Configuration.cc"
     "core/src/ConfigurationReader.cc"
     "core/src/ConfigurationSet.cc"
     "core/src/Graph.cc"

--- a/core/include/lua/utils.h
+++ b/core/include/lua/utils.h
@@ -3,8 +3,25 @@
 #include <boost/any.hpp>
 #include <lua.hpp>
 
-/// Utility functions related to lua configuration file parsing
+#include <logging.h>
+
+/*! \brief Utility functions related to lua configuration file parsing
+ *
+ * The lua configuration file specify a set of modules to execute.
+ *
+ * \todo describe how the configuration file is parsed and what it structure is
+ *
+ */
 namespace lua {
+
+    ///< Thrown if the configuration file is not valid
+    class invalid_configuration_file: public std::runtime_error {
+        using std::runtime_error::runtime_error;
+    };
+
+    class invalid_array_error: public std::runtime_error {
+        using std::runtime_error::runtime_error;
+    };
 
     /**
      * \brief List of all supported lua types
@@ -17,6 +34,33 @@ namespace lua {
         REAL, /**< Map to `double` */
         INPUT_TAG, /**< Map to InputTag */
         CONFIGURATION_SET, /**< Map to ConfigurationSet */
+    };
+
+    /**
+     * \brief Lazy value in lua
+     *
+     * It's just a small wrapper around a lua anonymous function.
+     *
+     * Use Lazy::operator()() to evaluate the function
+     */
+    struct Lazy {
+        lua_State* L; ///< The global lua state. This state must be valid for as long as this instance.
+        int ref_index; ///< The reference index where the anonymous function is stored.
+
+        /**
+         * \brief Evaluate the anonymous function
+         *
+         * \return The return value of the anonymous function
+         */
+        boost::any operator() () const;
+
+        /**
+         * \brief Bind a anonymous lua function
+         *
+         * \param L The current lua state.
+         * \param index The index of the anonymous function on the stack
+         */
+        Lazy(lua_State* L, int index);
     };
 
     /**
@@ -49,9 +93,11 @@ namespace lua {
     /**
      * \brief Convert a lua type to boost::any
      *
-     * \return A new boost::any encapsulating the lua type. If the lua type is not supported, an exception is thrown
+     * \return A std::pair containing :
+     *   - a new boost::any encapsulating the lua type and a boolean. If the lua type is not supported, an exception is thrown.
+     *   - a boolean. If true, it means the encapsulated type is a Lazy value, which must be evaluated later on.
      */
-    boost::any to_any(lua_State* L, int index);
+    std::pair<boost::any, bool> to_any(lua_State* L, int index);
 
     template<typename T> T special_any_cast(const boost::any& value) {
         return boost::any_cast<T>(value);
@@ -66,7 +112,6 @@ namespace lua {
     boost::any to_vectorT(lua_State* L, int index) {
 
         std::vector<T> result;
-
         size_t absolute_index = get_index(L, index);
 
         if (lua_type(L, absolute_index) != LUA_TTABLE)
@@ -74,7 +119,10 @@ namespace lua {
 
         lua_pushnil(L);
         while (lua_next(L, absolute_index) != 0) {
-            result.push_back(special_any_cast<T>(to_any(L, -1)));
+            boost::any value;
+            bool lazy = false;
+            std::tie(value, lazy) = to_any(L, -1);
+            result.push_back(special_any_cast<T>(value));
             lua_pop(L, 1);
         }
 
@@ -87,4 +135,68 @@ namespace lua {
      * \return A new boost::any encapsulating the lua array. If the lua type is not supported, an exception is thrown
      */
     boost::any to_vector(lua_State* L, int index, Type type);
+
+    /*!
+     *  \brief Register all C function in the lua userspace.
+     *
+     *  Available functions:
+     *      - @link load_modules @endlink
+     *      - @link parameter @endlink
+     */
+    void setup_hooks(lua_State* L, void* ptr);
+
+    /*!
+     * \brief Hook for the metatable `__newindex` of the module's table
+     *
+     * This function is called as soon as a new entry is added to a module's table, which means
+     * that the user defines a new module from the configuration.
+     *
+     * The stack contains 3 elements:
+     *  1. the module type table
+     *  2. the module name (the key in the table)
+     *  3. the module definition (the value associated with the key)
+     *
+     *  \return always 0
+     */
+    int module_table_newindex(lua_State* L);
+
+    /**
+     * \brief Register modules in lua userspace
+     *
+     * For each type of module existing, a global `table` named as
+     * the module's type is declared.
+     *
+     * Each entry in this table declare a new module of a given type. The key
+     * of the entry is the module's name, and the name of the table is the module's type.
+     *
+     * The value is itself a table, defining the configuration of the module
+     *
+     * \param L The current lua state
+     * \param ptr A pointer to an instance of ConfigurationReader
+     *
+     * \sa module_table_newindex()
+     */
+    void register_modules(lua_State* L, void* ptr);
+
+    /*!
+     * \brief Hook for the `load_modules` lua function. The stack must have one element:
+     *   1. (string) The filename of the library to load
+     *
+     * The library will be loaded, and for each new module, a new global variable will
+     * be declared, accessible from the lua configuration
+     *
+     * \return always 0
+     */
+    int load_modules(lua_State* L);
+
+    /*!
+     * \brief Hook for the `parameter` lua function. This function accepts one argument:
+     *   1. (string) The name of the parameter
+     *
+     * Internaly, this function creates an anonymous lua function, which returns the value of
+     * the parameter from the `configuration` global table.
+     *
+     * \return always 1
+     */
+    int parameter(lua_State* L);
 }

--- a/core/include/lua/utils.h
+++ b/core/include/lua/utils.h
@@ -3,37 +3,67 @@
 #include <boost/any.hpp>
 #include <lua.hpp>
 
+/// Utility functions related to lua configuration file parsing
 namespace lua {
 
+    /**
+     * \brief List of all supported lua types
+     */
     enum Type {
-        NOT_SUPPORTED,
-        BOOLEAN,
-        STRING,
-        INTEGER,
-        REAL,
-        INPUT_TAG,
-        CONFIGURATION_SET,
+        NOT_SUPPORTED, /**< Type not supported */
+        BOOLEAN, /**< Map to `bool` */
+        STRING, /**< Map to `std::string` */
+        INTEGER, /**< Map to `int64_t` */
+        REAL, /**< Map to `double` */
+        INPUT_TAG, /**< Map to InputTag */
+        CONFIGURATION_SET, /**< Map to ConfigurationSet */
     };
 
+    /**
+     * \brief Extract the type of a lua value
+     *
+     * \param L The current lua state
+     * \param index The index of the value
+     *
+     * \return The type of the lua value (can be ::NOT_SUPPORTED if the framework can't handle such value)
+     */
     Type type(lua_State* L, int index);
 
+    /**
+     * \brief Convert a negative lua stack index to an absolute index
+     *
+     * \param L The current lua state
+     * \param index The index to convert
+     *
+     * \return `index` if it's positive, otherwise the absolute index obtained by `lua_gettop(L) + index + 1`
+     */
     size_t get_index(lua_State* L, int index);
 
     /*!
-     *  Check if a lua table is an array
+     *  \brief Check if a lua table is an array
      *
-     *  Return -1 if it's not an array, or the size of the array
+     *  \return -1 if it's not an array, or the size of the array
      */
     int lua_is_array(lua_State* L, int index);
 
+    /**
+     * \brief Convert a lua type to boost::any
+     *
+     * \return A new boost::any encapsulating the lua type. If the lua type is not supported, an exception is thrown
+     */
     boost::any to_any(lua_State* L, int index);
 
     template<typename T> T special_any_cast(const boost::any& value) {
         return boost::any_cast<T>(value);
     }
 
+    /**
+     * \brief Convert a lua array to a typed vector, encapsulated into a boost::any
+     *
+     * \return A new boost::any encapsulating the lua array. If the lua type is not supported, an exception is thrown
+     */
     template<typename T>
-    std::vector<T> lua_to_vectorT(lua_State* L, int index) {
+    boost::any to_vectorT(lua_State* L, int index) {
 
         std::vector<T> result;
 
@@ -48,9 +78,13 @@ namespace lua {
             lua_pop(L, 1);
         }
 
-        return result;
+        return boost::any(result);
     }
 
-    boost::any lua_to_vector(lua_State* L, int index, Type type);
-    boost::any lua_to_vector(lua_State* L, int index);
+    /**
+     * \brief Convert a lua array to a typed vector, encapsulated into a boost::any
+     *
+     * \return A new boost::any encapsulating the lua array. If the lua type is not supported, an exception is thrown
+     */
+    boost::any to_vector(lua_State* L, int index, Type type);
 }

--- a/core/include/lua/utils.h
+++ b/core/include/lua/utils.h
@@ -5,6 +5,8 @@
 
 #include <logging.h>
 
+class IOnModuleDeclared;
+
 /*! \brief Utility functions related to lua configuration file parsing
  *
  * The lua configuration file specify a set of modules to execute.
@@ -199,4 +201,14 @@ namespace lua {
      * \return always 1
      */
     int parameter(lua_State* L);
+
+    /** \brief Initialize the lua runtime
+     *
+     * \param callback A pointer to an instance of IOnModuleDeclared. This callback is called
+     * when a new module is declared in the configuration file.
+     *
+     * \return A pointer to the global lua state. Once out-of-scope, the pointer will be
+     * released using the `lua_close` function.
+     */
+    std::shared_ptr<lua_State> init_runtime(IOnModuleDeclared* callback);
 }

--- a/core/src/Configuration.cc
+++ b/core/src/Configuration.cc
@@ -40,5 +40,7 @@ Configuration::Configuration(const ConfigurationReader& reader) {
     vegas_configuration.freeze();
     for (auto& module: modules) {
         module.parameters.freeze();
+        // Attach global configuration to each module
+        module.parameters.setGlobalConfiguration(global_configuration);
     }
 }

--- a/core/src/Configuration.cc
+++ b/core/src/Configuration.cc
@@ -1,0 +1,44 @@
+/*
+ *  MoMEMta: a modular implementation of the Matrix Element Method
+ *  Copyright (C) 2016  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <momemta/Configuration.h>
+#include <momemta/ConfigurationReader.h>
+
+const std::vector<Configuration::Module>& Configuration::getModules() const {
+    return modules;
+}
+
+const ConfigurationSet& Configuration::getVegasConfiguration() const {
+    return vegas_configuration;
+}
+
+const ConfigurationSet& Configuration::getGlobalConfiguration() const {
+    return global_configuration;
+}
+
+Configuration::Configuration(const ConfigurationReader& reader) {
+    modules = reader.m_modules;
+    global_configuration = *reader.m_global_configuration.get();
+    vegas_configuration = *reader.m_vegas_configuration.get();
+
+    global_configuration.freeze();
+    vegas_configuration.freeze();
+    for (auto& module: modules) {
+        module.parameters.freeze();
+    }
+}

--- a/core/src/ConfigurationReader.cc
+++ b/core/src/ConfigurationReader.cc
@@ -42,7 +42,7 @@ ConfigurationReader::ConfigurationReader(const std::string& file) {
     // FIXME: Find a better way of doing that
 
     // Read global configuration from global variable named 'configuration'
-    m_global_configuration.reset(new ConfigurationSet("configuration", "configuration"));
+    m_global_configuration.reset(new LazyConfigurationSet("configuration"));
     int type = lua_getglobal(lua_state.get(), "configuration");
     if (type == LUA_TTABLE) {
         LOG(debug) << "Parsing global configuration.";
@@ -51,7 +51,7 @@ ConfigurationReader::ConfigurationReader(const std::string& file) {
     lua_pop(lua_state.get(), 1);
 
     // Read vegas configuration
-    m_vegas_configuration.reset(new ConfigurationSet("vegas", "vegas"));
+    m_vegas_configuration.reset(new LazyConfigurationSet("vegas"));
     type = lua_getglobal(lua_state.get(), "vegas");
     if (type == LUA_TTABLE) {
         LOG(debug) << "Parsing vegas configuration.";
@@ -65,7 +65,7 @@ ConfigurationReader::ConfigurationReader(const std::string& file) {
         lua_getglobal(lua_state.get(), m.type.c_str());
         lua_getfield(lua_state.get(), -1, m.name.c_str());
 
-        m.parameters = ConfigurationSet(m.type, m.name, m_global_configuration);
+        m.parameters = ConfigurationSet(m.type, m.name);
         m.parameters.parse(lua_state.get(), -1);
 
         lua_pop(lua_state.get(), 2);
@@ -77,6 +77,14 @@ void ConfigurationReader::onModuleDeclared(const std::string& type, const std::s
     module.name = name;
     module.type = type;
     m_modules.push_back(module);
+}
+
+ConfigurationSet& ConfigurationReader::getGlobalConfiguration() {
+    return *m_global_configuration;
+}
+
+ConfigurationSet& ConfigurationReader::getVegasConfiguration() {
+    return *m_vegas_configuration;
 }
 
 Configuration ConfigurationReader::freeze() const {

--- a/core/src/ConfigurationReader.cc
+++ b/core/src/ConfigurationReader.cc
@@ -21,119 +21,11 @@
 #include <logging.h>
 #include <lua.hpp>
 
+#include <momemta/ConfigurationSet.h>
 #include <momemta/ConfigurationReader.h>
 #include <momemta/ModuleFactory.h>
 
-#include <LibraryManager.h>
 #include <lua/utils.h>
-
-namespace lua {
-
-    /*
-     * For each type of module existing, declare a global variable named like
-     * the module's type. This variable is a table.
-     *
-     * Each entry in this table declare a new module. The key of the entry is the module's name, and the name of the table where the entry is declared is the module's type. The value is iteself a table, defining the configuration of the module
-     *
-     */
-
-    /*!
-     * Hook for module declaration
-     *
-     * The stack contains 3 elements
-     *     1        the module type table
-     *     2        the module name (the key in the table)
-     *     3        the module definition (the value associated with the key)
-     */
-    int module_table_newindex(lua_State* L) {
-
-        lua_getmetatable(L, 1);
-        lua_getfield(L, -1, "__type");
-        
-        const char* module_type = luaL_checkstring(L, -1);
-        const char* module_name = luaL_checkstring(L, 2);
-
-        // Remove field name from stack
-        lua_pop(L, 1);
-
-        lua_getfield(L, -1, "__ptr");
-        void* cfg_ptr = lua_touserdata(L, -1);
-        ConfigurationReader* reader = static_cast<ConfigurationReader*>(cfg_ptr);
-
-        reader->addModule(module_type, module_name);
-        
-        // Remove metatable and field name from stack
-        lua_pop(L, 2);
-
-        // And actually set the value to the table
-        lua_rawset(L, 1);
-
-        return 0;
-    }
-
-    void lua_register_modules(lua_State* L, void* ptr) {
-        std::vector<std::string> modules = ModuleFactory::get().getPluginsList();
-        for (const auto& module: modules) {
-            const char* module_name = module.c_str();
-            char* module_metatable = new char[module.size() + 3 + 1];
-            strncpy(module_metatable, module_name, module.size() + 1);
-            strncat(module_metatable, "_mt", 3);
-
-            int type = lua_getglobal(L, module_name);
-            lua_pop(L, 1);
-            if (type != LUA_TNIL) {
-                // Global already exists
-                continue;
-            }
-
-            // Create a new empty table
-            lua_newtable(L);
-
-            // Create the associated metatable
-            luaL_newmetatable(L, module_metatable);
-
-            lua_pushstring(L, module_name);
-            lua_setfield(L, -2, "__type");
-
-            lua_pushlightuserdata(L, ptr);
-            lua_setfield(L, -2, "__ptr");
-
-            // Set the metadata '__newindex' function
-            const luaL_Reg l[] = {
-                {"__newindex", lua::module_table_newindex},
-                {nullptr, nullptr}
-            };
-            luaL_setfuncs(L, l, 0);
-
-            lua_setmetatable(L, -2);
-
-            // And register it as a global variable
-            lua_setglobal(L, module_name);
-
-            TRACE("Registered new lua global variable '{}'", module_name);
-
-            delete[] module_metatable;
-        }
-    }
-
-    /*!
-     * Hook for the 'load_modules' lua function. The stack must have one element:
-     *     1        (string) The filename of the library to load
-     *
-     * The library will be loaded, and for each module declared, a new global variable will
-     * be declared, accessible in the lua configuration
-     */
-    int load_modules(lua_State* L) {
-        void* cfg_ptr = lua_touserdata(L, lua_upvalueindex(1));
-
-        const char *path = luaL_checkstring(L, 1);
-        LibraryManager::get().registerLibrary(path);
-
-        lua_register_modules(L, cfg_ptr);
-
-        return 0;
-    }
-}
 
 ConfigurationReader::ConfigurationReader(const std::string& file) {
 
@@ -143,16 +35,16 @@ ConfigurationReader::ConfigurationReader(const std::string& file) {
     luaL_openlibs(lua_state);
 
     // Register function load_modules
-    lua_pushlightuserdata(lua_state, this);
-    lua_pushcclosure(lua_state, lua::load_modules, 1);
-    lua_setglobal(lua_state, "load_modules");
+    lua::setup_hooks(lua_state, this);
 
     // Register existing modules
-    lua::lua_register_modules(lua_state, this);
+    lua::register_modules(lua_state, this);
 
     // Parse file
     if (luaL_dofile(lua_state, file.c_str())) {
-        printf("%s\n", lua_tostring(lua_state, -1));
+        std::string error = lua_tostring(lua_state, -1);
+        LOGGER->critical("Failed to parse configuration file: {}", error);
+        throw lua::invalid_configuration_file(error);
     }
 
     // FIXME: Find a better way of doing that
@@ -175,14 +67,14 @@ ConfigurationReader::ConfigurationReader(const std::string& file) {
     }
     lua_pop(lua_state, 1);
 
-    for (auto& m: m_light_modules) {
+    for (auto& m: m_modules) {
         LOG(debug) << "Configuration declared module " << m.type << "::" << m.name;
 
         lua_getglobal(lua_state, m.type.c_str());
         lua_getfield(lua_state, -1, m.name.c_str());
 
-        m.parameters.reset(new ConfigurationSet(m.type, m.name, m_global_configuration));
-        m.parameters->parse(lua_state, -1);
+        m.parameters = ConfigurationSet(m.type, m.name, m_global_configuration);
+        m.parameters.parse(lua_state, -1);
 
         lua_pop(lua_state, 2);
     }
@@ -194,12 +86,12 @@ ConfigurationReader::~ConfigurationReader() {
 }
 
 void ConfigurationReader::addModule(const std::string& type, const std::string& name) {
-    LightModule module;
+    Configuration::Module module;
     module.name = name;
     module.type = type;
-    m_light_modules.push_back(module);
+    m_modules.push_back(module);
 }
 
-std::vector<LightModule> ConfigurationReader::getModules() const {
-    return m_light_modules;
+Configuration ConfigurationReader::freeze() const {
+    return Configuration(*this);
 }

--- a/core/src/ConfigurationSet.cc
+++ b/core/src/ConfigurationSet.cc
@@ -22,6 +22,19 @@
 #include <logging.h>
 #include <lua/utils.h>
 
+ConfigurationSet::ConfigurationSet(const std::string& module_type, const std::string& module_name) {
+    m_set.emplace("@type", module_type);
+    m_set.emplace("@name", module_name);
+}
+
+ConfigurationSet::ConfigurationSet(std::shared_ptr<ConfigurationSet> globalConfiguration) {
+    m_set.emplace("@global_configuration", globalConfiguration);
+}
+
+ConfigurationSet::ConfigurationSet(const std::string& module_type, const std::string& module_name, std::shared_ptr<ConfigurationSet> globalConfiguration): ConfigurationSet(module_type, module_name) {
+    m_set.emplace("@global_configuration", globalConfiguration);
+}
+
 void ConfigurationSet::parse(lua_State* L, int index) {
 
     TRACE("[parse] >> stack size = {}", lua_gettop(L));
@@ -38,7 +51,7 @@ void ConfigurationSet::parse(lua_State* L, int index) {
             boost::any value = lua::to_any(L, -1);
             m_set.emplace(key, value);
         } catch(...) {
-            LOG(emerg) << "Exception while trying to parse parameter " << m_module_type << "." << m_module_name << "::" << key;
+            LOG(emerg) << "Exception while trying to parse parameter " << getModuleType() << "." << getModuleName() << "::" << key;
             std::rethrow_exception(std::current_exception());
         }
 

--- a/core/src/MoMEMta.cc
+++ b/core/src/MoMEMta.cc
@@ -21,7 +21,8 @@
 
 #include <cuba.h>
 
-#include <momemta/ConfigurationReader.h>
+#include <momemta/ConfigurationSet.h>
+#include <momemta/Configuration.h>
 #include <momemta/MoMEMta.h>
 #include <momemta/Utils.h>
 
@@ -29,7 +30,7 @@
 #include <logging.h>
 
 
-MoMEMta::MoMEMta(const ConfigurationReader& configuration) {
+MoMEMta::MoMEMta(const Configuration& configuration) {
     
     // Initialize shared memory pool for modules
     m_pool.reset(new Pool());
@@ -43,10 +44,10 @@ MoMEMta::MoMEMta(const ConfigurationReader& configuration) {
     m_particles = m_pool->put<std::vector<LorentzVector>>({"input", "particles"});
 
     // Construct modules from configuration
-    std::vector<LightModule> light_modules = configuration.getModules();
+    std::vector<Configuration::Module> light_modules = configuration.getModules();
     for (const auto& module: light_modules) {
         m_pool->current_module(module.name);
-        m_modules.push_back(ModuleFactory::get().create(module.type, m_pool, *module.parameters));
+        m_modules.push_back(ModuleFactory::get().create(module.type, m_pool, module.parameters));
         m_modules.back()->configure();
     }
 
@@ -96,21 +97,21 @@ std::vector<std::pair<double, double>> MoMEMta::computeWeights(const std::vector
     double mcResult = 0, prob = 0, error = 0;
 
     // Read vegas configuration
-    uint8_t verbosity = m_vegas_configuration->get<int64_t>("verbosity", 0);
-    bool subregion = m_vegas_configuration->get<bool>("subregion", false);
-    bool smoothing = m_vegas_configuration->get<bool>("smoothing", false);
-    bool retainStateFile = m_vegas_configuration->get<bool>("retainStateFile", false);
-    bool takeOnlyGridFromFile = m_vegas_configuration->get<bool>("takeOnlyGridFromFile", true);
-    uint64_t level = m_vegas_configuration->get<int64_t>("level", 0);
+    uint8_t verbosity = m_vegas_configuration.get<int64_t>("verbosity", 0);
+    bool subregion = m_vegas_configuration.get<bool>("subregion", false);
+    bool smoothing = m_vegas_configuration.get<bool>("smoothing", false);
+    bool retainStateFile = m_vegas_configuration.get<bool>("retainStateFile", false);
+    bool takeOnlyGridFromFile = m_vegas_configuration.get<bool>("takeOnlyGridFromFile", true);
+    uint64_t level = m_vegas_configuration.get<int64_t>("level", 0);
 
-    double relative_accuracy = m_vegas_configuration->get<double>("relative_accuracy", 0.005);
-    double absolute_accuracy = m_vegas_configuration->get<double>("absolute_accuracy", 0.);
-    int64_t seed = m_vegas_configuration->get<int64_t>("seed", 0);
-    int64_t min_eval = m_vegas_configuration->get<int64_t>("min_eval", 0);
-    int64_t max_eval = m_vegas_configuration->get<int64_t>("max_eval", 500000);
-    int64_t n_start = m_vegas_configuration->get<int64_t>("n_start", 25000);
-    int64_t n_increase = m_vegas_configuration->get<int64_t>("n_increase", 0);
-    int64_t batch_size = m_vegas_configuration->get<int64_t>("batch_size", 12500);
+    double relative_accuracy = m_vegas_configuration.get<double>("relative_accuracy", 0.005);
+    double absolute_accuracy = m_vegas_configuration.get<double>("absolute_accuracy", 0.);
+    int64_t seed = m_vegas_configuration.get<int64_t>("seed", 0);
+    int64_t min_eval = m_vegas_configuration.get<int64_t>("min_eval", 0);
+    int64_t max_eval = m_vegas_configuration.get<int64_t>("max_eval", 500000);
+    int64_t n_start = m_vegas_configuration.get<int64_t>("n_start", 25000);
+    int64_t n_increase = m_vegas_configuration.get<int64_t>("n_increase", 0);
+    int64_t batch_size = m_vegas_configuration.get<int64_t>("batch_size", 12500);
 
     unsigned int flags = vegas::createFlagsBitset(verbosity, subregion, retainStateFile, level, smoothing, takeOnlyGridFromFile);
 

--- a/core/src/lua/utils.cc
+++ b/core/src/lua/utils.cc
@@ -163,10 +163,8 @@ namespace lua {
                     Type type = NOT_SUPPORTED;
 
                     if ((type = lua::lua_array_unique_type(L, absolute_index)) != NOT_SUPPORTED) {
-                        result = lua_to_vector(L, absolute_index, type);
+                        result = to_vector(L, absolute_index, type);
                     } else {
-                        // Convert to a vector of boost::any
-                        // result = lua_to_vector(L, absolute_index);
                         throw invalid_array_error("Various types stored into the array. This is not supported.");
                     }
 
@@ -184,48 +182,31 @@ namespace lua {
         return result;
     }
 
-    boost::any lua_to_vector(lua_State* L, int index, Type t) {
+    boost::any to_vector(lua_State* L, int index, Type t) {
         switch (t) {
             case BOOLEAN:
-                return boost::any(lua_to_vectorT<bool>(L, index));
+                return to_vectorT<bool>(L, index);
 
             case STRING:
-                return boost::any(lua_to_vectorT<std::string>(L, index));
+                return to_vectorT<std::string>(L, index);
 
             case INTEGER:
-                return boost::any(lua_to_vectorT<int64_t>(L, index));
+                return to_vectorT<int64_t>(L, index);
 
             case REAL:
-                return boost::any(lua_to_vectorT<double>(L, index));
+                return to_vectorT<double>(L, index);
 
             case INPUT_TAG:
-                return boost::any(lua_to_vectorT<InputTag>(L, index));
+                return to_vectorT<InputTag>(L, index);
 
             case CONFIGURATION_SET:
-                return boost::any(lua_to_vectorT<ConfigurationSet>(L, index));
+                return to_vectorT<ConfigurationSet>(L, index);
 
             case NOT_SUPPORTED:
                 break;
         }
 
         throw invalid_array_error("Unsupported array type");
-    }
-
-    boost::any lua_to_vector(lua_State* L, int index) {
-        std::vector<boost::any> result;
-
-        size_t absolute_index = get_index(L, index);
-
-        if (lua_type(L, absolute_index) != LUA_TTABLE)
-            return result;
-
-        lua_pushnil(L);
-        while (lua_next(L, absolute_index) != 0) {
-            result.push_back(to_any(L, -1));
-            lua_pop(L, 1);
-        }
-
-        return result;
     }
 
     //! Specialization for double type, with implicit conversion from integer

--- a/core/src/lua/utils.cc
+++ b/core/src/lua/utils.cc
@@ -171,7 +171,7 @@ namespace lua {
                     }
 
                 } else {
-                    ConfigurationSet cfg("", "");
+                    ConfigurationSet cfg;
                     cfg.parse(L, absolute_index);
                     result = cfg;
                 }

--- a/docs/theme/Doxyfile.in
+++ b/docs/theme/Doxyfile.in
@@ -827,7 +827,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */external/* *@CMAKE_CURRENT_BINARY_DIR@/* */MatrixElements/*
+EXCLUDE_PATTERNS       = */external/* *@CMAKE_CURRENT_BINARY_DIR@/* */MatrixElements/* */tests/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/docs/theme/DoxygenLayout.xml
+++ b/docs/theme/DoxygenLayout.xml
@@ -84,6 +84,7 @@
   <!-- Layout definition for a namespace page -->
   <namespace>
     <briefdescription visible="yes"/>
+    <detaileddescription title=""/>
     <memberdecl>
       <nestednamespaces visible="yes" title=""/>
       <constantgroups visible="yes" title=""/>
@@ -94,7 +95,6 @@
       <variables title=""/>
       <membergroups visible="yes"/>
     </memberdecl>
-    <detaileddescription title=""/>
     <memberdef>
       <inlineclasses title=""/>
       <typedefs title=""/>
@@ -108,6 +108,7 @@
   <!-- Layout definition for a file page -->
   <file>
     <briefdescription visible="yes"/>
+    <detaileddescription title=""/>
     <includes visible="$SHOW_INCLUDE_FILES"/>
     <includegraph visible="$INCLUDE_GRAPH"/>
     <includedbygraph visible="$INCLUDED_BY_GRAPH"/>
@@ -123,7 +124,6 @@
       <variables title=""/>
       <membergroups visible="yes"/>
     </memberdecl>
-    <detaileddescription title=""/>
     <memberdef>
       <inlineclasses title=""/>
       <defines title=""/>
@@ -138,6 +138,7 @@
   <!-- Layout definition for a group page -->
   <group>
     <briefdescription visible="yes"/>
+    <detaileddescription title=""/>
     <groupgraph visible="$GROUP_GRAPHS"/>
     <memberdecl>
       <nestedgroups visible="yes" title=""/>
@@ -160,7 +161,6 @@
       <friends title=""/>
       <membergroups visible="yes"/>
     </memberdecl>
-    <detaileddescription title=""/>
     <memberdef>
       <pagedocs/>
       <inlineclasses title=""/>
@@ -184,11 +184,11 @@
   <!-- Layout definition for a directory page -->
   <directory>
     <briefdescription visible="yes"/>
+    <detaileddescription title=""/>
     <directorygraph visible="yes"/>
     <memberdecl>
       <dirs visible="yes"/>
       <files visible="yes"/>
     </memberdecl>
-    <detaileddescription title=""/>
   </directory>
 </doxygenlayout>

--- a/docs/theme/customdoxygen.css
+++ b/docs/theme/customdoxygen.css
@@ -123,7 +123,7 @@ dl.el {
     margin-left: -1cm;
 }
 
-dl.note {
+dl.note, dl.warning, dl.error, dl.todo {
   margin-left: -10px;
   padding-left: 6px;
 }
@@ -373,6 +373,7 @@ pre.code {
     padding: 0;
     margin: 0;
     border: 0;
+    margin-bottom: 20px;
 }
 
 pre {

--- a/docs/theme/customdoxygen.css
+++ b/docs/theme/customdoxygen.css
@@ -123,9 +123,22 @@ dl.el {
     margin-left: -1cm;
 }
 
-dl.note, dl.warning, dl.error, dl.todo {
+dl.note, dl.warning, dl.error, dl.todo, dl.attention {
   margin-left: -10px;
   padding-left: 6px;
+}
+
+dl.warning, dl.attention {
+    border-color: #a94442;
+}
+
+dl.note {
+    /*border-color: #3c763d;*/
+    border-color: #8a6d3b;
+}
+
+dl.todo {
+    border-color: #31708f;
 }
 
 pre.fragment {

--- a/docs/theme/doxy-boot.js
+++ b/docs/theme/doxy-boot.js
@@ -234,8 +234,8 @@ $(document).ready(function() {
         });
 
     // todo list
-    var todoelements = $(
-        '.contents > .textblock > dl.reflist > dt, .contents > .textblock > dl.reflist > dd');
+    var todoelements = $('.contents > .textblock > dl.reflist > dt, .contents > .textblock > dl.reflist > dd');
+    $('.contents > .textblock > .reflist').detach();
     for (var i = 0; i < todoelements.length; i += 2) {
         $('.contents > .textblock')
             .append(
@@ -245,8 +245,26 @@ $(document).ready(function() {
                 "<div class=\"panel-body\">" + $(todoelements[i + 1]).html() +
                 "</div>" + '</div>');
     }
-    $('.contents > .textblock > dl').remove();
 
+    /*$('dl.section').each(function(i, block) {
+      header = $(block).children('dt').text();
+      text = $(block).children('dd').html();
+
+      clazz = '';
+      if (header == 'Warning')
+          clazz = 'warning';
+      else if (header == 'Note')
+          clazz = 'info';
+
+      header = $(block).children('dt').html();
+
+      panel = '<div class="panel panel-' + clazz + '">' +
+                  '<div class="panel-heading">' + header + '</div>' +
+                  '<div class="panel-body">' + text + '</div>' +
+              '</div>';
+
+      $(block).replaceWith(panel);
+    });*/
 
     $(".memitem").removeClass('memitem');
     $(".memproto").removeClass('memproto');
@@ -294,11 +312,18 @@ $(document).ready(function() {
     $('div.line-number > pre > code').each(function(i, node) {
 
         // Re-add line numbers
+
         code = $(node).html().split('\n');
+        if (!code[code.length - 1])
+            code.pop();
+
         flat_code = '';
         for (index = 0; index < code.length; ++index) {
             flat_code += '<a name="l' + pad(index + 1, 5) + '" href="#"></a><span class="line"></span>' + code[index] + '\n';
         }
+
+        // Remove latest end-of-line
+        flat_code = flat_code.slice(0, -1);
 
         $(node).html(flat_code);
     });

--- a/examples/tt_fullyleptonic.cc
+++ b/examples/tt_fullyleptonic.cc
@@ -33,6 +33,10 @@ int main(int argc, char** argv) {
     spdlog::set_level(spdlog::level::trace);
 
     ConfigurationReader configuration("../examples/tt_fullyleptonic.lua");
+
+    // Change top mass
+    configuration.getGlobalConfiguration().set("top_mass", 173.);
+
     MoMEMta weight(configuration.freeze());
 
     // Electron

--- a/examples/tt_fullyleptonic.cc
+++ b/examples/tt_fullyleptonic.cc
@@ -17,6 +17,7 @@
  */
 
 
+#include <momemta/ConfigurationReader.h>
 #include <momemta/MoMEMta.h>
 #include <momemta/Utils.h>
 
@@ -32,7 +33,7 @@ int main(int argc, char** argv) {
     spdlog::set_level(spdlog::level::trace);
 
     ConfigurationReader configuration("../examples/tt_fullyleptonic.lua");
-    MoMEMta weight(configuration);
+    MoMEMta weight(configuration.freeze());
 
     // Electron
     LorentzVector p3(16.171895980835, -13.7919054031372, -3.42997527122497, 21.5293197631836);

--- a/examples/tt_fullyleptonic.lua
+++ b/examples/tt_fullyleptonic.lua
@@ -9,11 +9,6 @@ end
 load_modules('libempty_module.so')
 load_modules('MatrixElements/dummy/libme_dummy.so')
 
-M_W = 80.419002
-M_TOP = 173.
-W_W = 2.047600e+00
-W_TOP = 1.491500e+00
-
 USE_TF = true
 
 if USE_TF then
@@ -51,8 +46,10 @@ end
 
 configuration = {
     energy = 13000.,
-    top_mass = M_TOP,
-    W_mass = M_W
+    top_mass = 173.,
+    top_width = 1.491500,
+    W_mass = 80.419002,
+    W_width = 2.047600,
 }
 
 vegas = {
@@ -61,26 +58,26 @@ vegas = {
 
 Flatter.flatter_s13 = {
     input = "cuba::ps_points/0",
-    mass = M_W,
-    width = W_W
+    mass = parameter('W_mass'),
+    width = parameter('W_width')
 }
 
 Flatter.flatter_s134 = {
     input = "cuba::ps_points/1",
-    mass = M_TOP,
-    width = W_TOP
+    mass = parameter('top_mass'),
+    width = parameter('top_width')
 }
 
 Flatter.flatter_s25 = {
     input = "cuba::ps_points/2",
-    mass = M_W,
-    width = W_W
+    mass = parameter('W_mass'),
+    width = parameter('W_width')
 }
 
 Flatter.flatter_s256 = {
     input = "cuba::ps_points/3",
-    mass = M_TOP,
-    width = W_TOP
+    mass = parameter('top_mass'),
+    width = parameter('top_width')
 }
 
 if USE_TF then

--- a/examples/tt_fullyleptonic_NWA.cc
+++ b/examples/tt_fullyleptonic_NWA.cc
@@ -17,6 +17,7 @@
  */
 
 
+#include <momemta/ConfigurationReader.h>
 #include <momemta/MoMEMta.h>
 #include <momemta/Utils.h>
 
@@ -32,7 +33,7 @@ int main(int argc, char** argv) {
     spdlog::set_level(spdlog::level::trace);
 
     ConfigurationReader configuration("../examples/tt_fullyleptonic_NWA.lua");
-    MoMEMta weight(configuration);
+    MoMEMta weight(configuration.freeze());
 
     // Electron
     LorentzVector p3(16.171895980835, -13.7919054031372, -3.42997527122497, 21.5293197631836);

--- a/examples/tt_fullyleptonic_NWA.lua
+++ b/examples/tt_fullyleptonic_NWA.lua
@@ -1,8 +1,3 @@
-M_W = 80.419002
-M_TOP = 173.
-W_W = 2.047600e+00
-W_TOP = 1.491500e+00
-
 -- Use transfer functions
 inputs_before_perm = {
     'tf_p1::output',
@@ -21,8 +16,10 @@ inputs = {
 
 configuration = {
     energy = 13000.,
-    top_mass = M_TOP,
-    W_mass = M_W
+    top_mass = 173.,
+    top_width = 1.491500,
+    W_mass = 80.419002,
+    W_width = 2.047600,
 }
 
 vegas = {
@@ -31,23 +28,23 @@ vegas = {
 
 -- Use the narrow width approximation for both Top & W propagators
 NarrowWidthApproximation.nwa_s13 = {
-    mass = M_W,
-    width = W_W
+    mass = parameter('W_mass'),
+    width = parameter('W_width')
 }
 
 NarrowWidthApproximation.nwa_s134 = {
-    mass = M_TOP,
-    width = W_TOP
+    mass = parameter('top_mass'),
+    width = parameter('top_width')
 }
 
 NarrowWidthApproximation.nwa_s25 = {
-    mass = M_W,
-    width = W_W
+    mass = parameter('W_mass'),
+    width = parameter('W_width')
 }
 
 NarrowWidthApproximation.nwa_s256 = {
-    mass = M_TOP,
-    width = W_TOP
+    mass = parameter('top_mass'),
+    width = parameter('top_width')
 }
 
 GaussianTransferFunction.tf_p1 = {

--- a/include/momemta/Configuration.h
+++ b/include/momemta/Configuration.h
@@ -1,0 +1,60 @@
+/*
+ *  MoMEMta: a modular implementation of the Matrix Element Method
+ *  Copyright (C) 2016  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <momemta/ConfigurationSet.h>
+
+class ConfigurationReader;
+
+/**
+ * \brief A frozen snapshot of the configuration file.
+ *
+ * All the parameters are enforced to be static (ie, all lua::Lazy parameters are evaluated)
+ */
+class Configuration {
+    public:
+        /**
+         * \brief A module defined from the configuration file
+         *
+         * Stores the name, type and parameters of the module
+         */
+        struct Module {
+            std::string name; ///< Name of the module (user-defined from the configuration file)
+            std::string type; ///< Type of the module (mapped one-to-one with a C++ class inherting from Module)
+            ConfigurationSet parameters; ///< Module's parameters, as parsed from the configuration file
+        };
+
+        /// \return The list of modules declared from the configuration file
+        const std::vector<Module>& getModules() const;
+        /// \return The vegas configuration as declared in the configuration file
+        const ConfigurationSet& getVegasConfiguration() const;
+        /// \return The global configuration as declared in the configuration file
+        const ConfigurationSet& getGlobalConfiguration() const;
+
+    private:
+        friend class ConfigurationReader;
+        Configuration(const ConfigurationReader&);
+
+        std::vector<Module> modules;
+        ConfigurationSet global_configuration;
+        ConfigurationSet vegas_configuration;
+};

--- a/include/momemta/ConfigurationReader.h
+++ b/include/momemta/ConfigurationReader.h
@@ -23,16 +23,23 @@
 #include <string>
 #include <vector>
 
-#include <momemta/ConfigurationSet.h>
+#include <momemta/Configuration.h>
 
-struct LightModule {
-    std::string name;
-    std::string type;
-    std::shared_ptr<ConfigurationSet> parameters;
-};
-
+class ConfigurationSet;
 class lua_State;
 
+/**
+ * \brief A lua configuration file parser
+ *
+ * This class handles the parsing of the lua configuration file. The configuration files describes which modules should be run in order to form an integrand. This integrand is then integrated using CUBA and MoMEMta and the result of the integral is returned.
+ *
+ * A module is a single element of a more complex scheme. Itself, it only performs a simple tasks (flattening a Breit-Wigner for example), but combined with other modules, it's possible to define complex integrand.
+ *
+ * A module can be seen like a box with a fixed number of inputs and outputs. The configuration file is used to specify a list of module to run, and to connect outputs of modules to inputs of other modules.
+ *
+ * \todo Discuss the `configuration` table, `vegas` table and the concept of freezing and delayed execution
+ *
+ */
 class ConfigurationReader {
     public:
         ConfigurationReader(const std::string&);
@@ -40,14 +47,17 @@ class ConfigurationReader {
 
         void addModule(const std::string& type, const std::string& name);
 
-        std::vector<LightModule> getModules() const;
-
-        std::shared_ptr<ConfigurationSet> getVegasConfiguration() const {
-            return m_vegas_configuration;
-        }
+        /**
+         * \brief Freeze the configuration
+         *
+         * \return A freezed copy of the configuration
+         */
+        Configuration freeze() const;
 
     private:
-        std::vector<LightModule> m_light_modules;
+        friend class Configuration;
+
+        std::vector<Configuration::Module> m_modules;
         std::shared_ptr<ConfigurationSet> m_global_configuration;
         std::shared_ptr<ConfigurationSet> m_vegas_configuration;
 

--- a/include/momemta/ConfigurationReader.h
+++ b/include/momemta/ConfigurationReader.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include <momemta/Configuration.h>
+#include <momemta/IOnModuleDeclared.h>
 
 class ConfigurationSet;
 class lua_State;
@@ -40,12 +41,11 @@ class lua_State;
  * \todo Discuss the `configuration` table, `vegas` table and the concept of freezing and delayed execution
  *
  */
-class ConfigurationReader {
+class ConfigurationReader: public IOnModuleDeclared {
     public:
         ConfigurationReader(const std::string&);
-        virtual ~ConfigurationReader();
 
-        void addModule(const std::string& type, const std::string& name);
+        virtual void onModuleDeclared(const std::string& type, const std::string& name) override;
 
         /**
          * \brief Freeze the configuration
@@ -61,5 +61,5 @@ class ConfigurationReader {
         std::shared_ptr<ConfigurationSet> m_global_configuration;
         std::shared_ptr<ConfigurationSet> m_vegas_configuration;
 
-        lua_State* lua_state = nullptr;
+        std::shared_ptr<lua_State> lua_state;
 };

--- a/include/momemta/ConfigurationReader.h
+++ b/include/momemta/ConfigurationReader.h
@@ -47,6 +47,9 @@ class ConfigurationReader: public IOnModuleDeclared {
 
         virtual void onModuleDeclared(const std::string& type, const std::string& name) override;
 
+        ConfigurationSet& getGlobalConfiguration();
+        ConfigurationSet& getVegasConfiguration();
+
         /**
          * \brief Freeze the configuration
          *

--- a/include/momemta/ConfigurationSet.h
+++ b/include/momemta/ConfigurationSet.h
@@ -54,18 +54,19 @@ class ConfigurationSet {
         void parse(lua_State* L, int index);
 
         std::string getModuleName() const {
-            return m_module_name;
+            return get<std::string>("@name", "");
         }
 
         std::string getModuleType() const {
-            return m_module_type;
+            return get<std::string>("@type", "");
         }
 
         const ConfigurationSet& globalConfiguration() const {
-            if (m_global_configuration.get())
-                return *m_global_configuration;
-            else
+            auto it = m_set.find("@global_configuration");
+            if (it == m_set.end())
                 return *this;
+
+            return *boost::any_cast<std::shared_ptr<ConfigurationSet>>(it->second);
         }
 
     private:
@@ -76,17 +77,10 @@ class ConfigurationSet {
         friend class ConfigurationReader;
         friend boost::any lua::to_any(lua_State* L, int index);
 
+        ConfigurationSet() = default;
+        ConfigurationSet(std::shared_ptr<ConfigurationSet> globalConfiguration);
+        ConfigurationSet(const std::string& module_type, const std::string& module_name);
+        ConfigurationSet(const std::string& module_type, const std::string& module_name, std::shared_ptr<ConfigurationSet> globalConfiguration);
 
-        ConfigurationSet(const std::string& module_type, const std::string& module_name):
-            m_module_type(module_type),
-            m_module_name(module_name) {}
-
-        ConfigurationSet(const std::string& module_type, const std::string& module_name, std::shared_ptr<ConfigurationSet> globalConfiguration): ConfigurationSet(module_type, module_name) {
-            m_global_configuration = globalConfiguration;
-        }
-
-        std::string m_module_type;
-        std::string m_module_name;
         std::map<std::string, boost::any> m_set;
-        std::shared_ptr<ConfigurationSet> m_global_configuration;
 };

--- a/include/momemta/IOnModuleDeclared.h
+++ b/include/momemta/IOnModuleDeclared.h
@@ -1,0 +1,49 @@
+/*
+ *  MoMEMta: a modular implementation of the Matrix Element Method
+ *  Copyright (C) 2016  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include <string>
+
+/**
+ * \brief Notification callback fired when a module is declared.
+ *
+ * This callback is used from the lua interface when the user declare a new module in the
+ * configuration file.
+ */
+class IOnModuleDeclared {
+    public:
+        virtual ~IOnModuleDeclared() {};
+
+        /** \brief A module is declared in the configuration file
+         *
+         * This function is called as soon as a new module is declared in the configuration
+         * file.
+         *
+         * A lua code like
+         *
+         * ```
+         * MatrixElement.module_name = {}
+         * ```
+         *
+         * will result in a call to this function with \p type equals to `MatrixElement` and
+         * \p name equals to `module_name`.
+         */
+        virtual void onModuleDeclared(const std::string& type, const std::string& name) = 0;
+};

--- a/include/momemta/MoMEMta.h
+++ b/include/momemta/MoMEMta.h
@@ -23,16 +23,17 @@
 #include <vector>
 
 #include <logging.h>
-#include <momemta/ConfigurationReader.h>
+#include <momemta/ConfigurationSet.h>
 #include <momemta/Module.h>
 #include <momemta/Pool.h>
 #include <momemta/Types.h>
 
+class Configuration;
 class SharedLibrary;
 
 class MoMEMta {
     public:
-        MoMEMta(const ConfigurationReader&);
+        MoMEMta(const Configuration&);
         virtual ~MoMEMta();
 
         std::vector<std::pair<double, double>> computeWeights(const std::vector<LorentzVector>& particules);
@@ -50,7 +51,7 @@ class MoMEMta {
         std::vector<SharedLibraryPtr> m_libraries;
 
         size_t m_n_dimensions;
-        std::shared_ptr<ConfigurationSet> m_vegas_configuration;
+        ConfigurationSet m_vegas_configuration;
 
         // Pool inputs
         std::shared_ptr<std::vector<double>> m_ps_points;

--- a/tests/phaseSpaceVolume/blockD.cc
+++ b/tests/phaseSpaceVolume/blockD.cc
@@ -17,6 +17,7 @@
  */
 
 
+#include <momemta/ConfigurationReader.h>
 #include <momemta/MoMEMta.h>
 #include <momemta/Utils.h>
 
@@ -32,7 +33,7 @@ int main(int argc, char** argv) {
     spdlog::set_level(spdlog::level::trace);
 
     ConfigurationReader configuration("../tests/phaseSpaceVolume/blockD.lua");
-    MoMEMta weight(configuration);
+    MoMEMta weight(configuration.freeze());
 
     // Electron
     LorentzVector p3(25, 0, 0, 25);


### PR DESCRIPTION
A lazy value is an expression whose evaluation is delayed. In our context,
it essentially means a value which can be changed after the configuration
file is parsed.

An new lua function is added, `parameter` which accepts a string argument.
Instead of referencing directly the variable in the lua configuration, the
user must use this new function, and pass as argument the name of the
parameter, as specified in the `configuration` table (see updated lua
configuration for an example)

It's also now possible to edit parameters directly from the code instead of the configuration file. The new philosophy is now:

 1. You open a lua configuration file using `ConfigurationReader`
 2. You (may) edit the parameters you want
 3. You *freeze* the reader and receive a cloned version of the configuration that you can no longer edit.
 4. You use the frozen version of the configuration to create an instance of MoMEMta.
 5. Go back to step 2 if you want

--

TODO before merging:

 - [x] Ensure that a given parameter actually exists in the `configuration` table when evaluating the Lazy function (currently give a cryptic message)
 - [x] Support editing of a given parameter after the evaluation of the configuration file