### PR TITLE
Build cuba using 64-bits integers

### DIFF
--- a/core/src/MoMEMta.cc
+++ b/core/src/MoMEMta.cc
@@ -93,9 +93,6 @@ std::vector<std::pair<double, double>> MoMEMta::computeWeights(const std::vector
 
     *m_particles = particules;
 
-    int neval, nfail;
-    double mcResult = 0, prob = 0, error = 0;
-
     // Read vegas configuration
     uint8_t verbosity = m_vegas_configuration.get<int64_t>("verbosity", 0);
     bool subregion = m_vegas_configuration.get<bool>("subregion", false);
@@ -115,7 +112,12 @@ std::vector<std::pair<double, double>> MoMEMta::computeWeights(const std::vector
 
     unsigned int flags = vegas::createFlagsBitset(verbosity, subregion, retainStateFile, level, smoothing, takeOnlyGridFromFile);
 
-    Vegas(
+    // Output from cuba
+    long long int neval = 0;
+    int nfail = 0;
+    double mcResult = 0, prob = 0, error = 0;
+
+    llVegas(
          m_n_dimensions,         // (int) dimensions of the integrated volume
          1,                      // (int) dimensions of the integrand
          (integrand_t) CUBAIntegrand,  // (integrand_t) integrand (cast to integrand_t)

--- a/external/cuba/CMakeLists.txt
+++ b/external/cuba/CMakeLists.txt
@@ -1,8 +1,7 @@
 add_definitions(-DHAVE_CONFIG_H)
 add_definitions(-DREAL_SIZE=8)
 add_definitions(-DNOUNDERSCORE)
-
-#add_definitions(-DLONGLONGINT)
+add_definitions(-DLONGLONGINT)
 
 include_directories(.)
 include_directories(src/common)


### PR DESCRIPTION
Title says everything. This allows to use more than 2 147 483 647 iterations, which seems to be necessary to compute the phase-space volume.

Credits go to @swertz!