### PR TITLE
Define CubaIndex() function to generate cuba PS point input tag

### DIFF
--- a/core/include/lua/utils.h
+++ b/core/include/lua/utils.h
@@ -262,4 +262,15 @@ namespace lua {
      * released using the `lua_close` function.
      */
     std::shared_ptr<lua_State> init_runtime(IOnModuleDeclared* callback);
+   
+    /** \brief Define Lua function to generate Cuba phase-space point input-tags
+     *
+     * \param L The current lua state
+     *
+     * The function allows creating a Lua function return an input tag of type `cuba::ps_points/i` where `i` gets incremented each time the function is called (starting from 0).
+     * This way, the user is sure to always define the correct input tag fothe phase-space points.
+     *
+     * \return always 1
+     */
+    int generate_cuba_index(lua_State* L);
 }

--- a/core/src/lua/utils.cc
+++ b/core/src/lua/utils.cc
@@ -452,6 +452,12 @@ namespace lua {
         lua_pushlightuserdata(L, ptr);
         lua_pushcclosure(L, parameter, 1);
         lua_setglobal(L, "parameter");
+
+        // Define the `CubaIndex()` function in Lua and make it available in the global namespace.
+        // See generate_cuba_index for more information.
+        lua_pushnumber(L, 0);
+        lua_pushcclosure(L, generate_cuba_index, 1);
+        lua_setglobal(L, "CubaIndex");
     }
 
     std::shared_ptr<lua_State> init_runtime(IOnModuleDeclared* callback) {
@@ -464,8 +470,26 @@ namespace lua {
 
         // Register existing modules
         lua::register_modules(L.get(), callback);
-
+    
         return L;
+    }
 
+    int generate_cuba_index(lua_State* L) {
+        int n = lua_gettop(L);
+        if (n != 0) {
+            luaL_error(L, "invalid number of arguments: 0 expected, got %d", n);
+        }
+
+        // Create input tag using current value of the index
+        int64_t cuba_index = lua_tonumber(L, lua_upvalueindex(1));
+        lua_pushnumber(L, cuba_index + 1);
+        lua_replace(L, lua_upvalueindex(1));
+
+        std::string index_tag = "cuba::ps_points/";
+        index_tag += std::to_string(cuba_index);
+
+        push_any(L, index_tag);
+
+        return 1;
     }
 }

--- a/examples/tt_fullyleptonic.lua
+++ b/examples/tt_fullyleptonic.lua
@@ -56,39 +56,41 @@ vegas = {
     verbosity = 3
 }
 
-Flatter.flatter_s13 = {
-    input = "cuba::ps_points/0",
+Flatter.flatter_s13 = { 
+    -- CubaIndex() generates an input tag of type `cuba::ps_points/i`
+    -- where `i` is automatically incremented each time the function is called.
+    input = CubaIndex(),
     mass = parameter('W_mass'),
     width = parameter('W_width')
 }
 
 Flatter.flatter_s134 = {
-    input = "cuba::ps_points/1",
+    input = CubaIndex(),
     mass = parameter('top_mass'),
     width = parameter('top_width')
 }
 
 Flatter.flatter_s25 = {
-    input = "cuba::ps_points/2",
+    input = CubaIndex(), 
     mass = parameter('W_mass'),
     width = parameter('W_width')
 }
 
 Flatter.flatter_s256 = {
-    input = "cuba::ps_points/3",
+    input = CubaIndex(),
     mass = parameter('top_mass'),
     width = parameter('top_width')
 }
 
 if USE_TF then
     GaussianTransferFunction.tf_p1 = {
-        ps_point = 'cuba::ps_points/4',
+        ps_point = CubaIndex(),
         reco_particle = 'input::particles/0',
         sigma = 0.05,
     }
 
     GaussianTransferFunction.tf_p2 = {
-        ps_point = 'cuba::ps_points/5',
+        ps_point = CubaIndex(),
         reco_particle = 'input::particles/1',
         sigma = 0.10,
     }
@@ -102,13 +104,13 @@ if USE_TF then
     -- }
 
     GaussianTransferFunction.tf_p3 = {
-        ps_point = 'cuba::ps_points/6',
+        ps_point = CubaIndex(),
         reco_particle = 'input::particles/2',
         sigma = 0.05,
     }
 
     GaussianTransferFunction.tf_p4 = {
-        ps_point = 'cuba::ps_points/7',
+        ps_point = CubaIndex(),
         reco_particle = 'input::particles/3',
         sigma = 0.10,
     }
@@ -122,13 +124,8 @@ if USE_TF then
 end
 
 if USE_PERM then
-    cuba_index = '4'
-    if USE_TF then
-        cuba_index = '8'
-    end
-    
     Permutator.permutator = {
-        ps_point = 'cuba::ps_points/' .. cuba_index,
+        ps_point = CubaIndex(), 
         input = {
           inputs_before_perm[2],
           inputs_before_perm[4],

--- a/tests/unit_tests/lua.cc
+++ b/tests/unit_tests/lua.cc
@@ -31,6 +31,7 @@
 #include <momemta/ConfigurationSet.h>
 #include <momemta/IOnModuleDeclared.h>
 #include <momemta/ModuleFactory.h>
+#include <momemta/InputTag.h>
 
 #include <lua/utils.h>
 
@@ -61,9 +62,21 @@ TEST_CASE("lua parsing utilities", "[lua]") {
 
     auto stack_size = lua_gettop(L.get());
 
-    SECTION("custom functions exist") {
+    SECTION("custom functions") {
         execute_string(L, "load_modules('not_existing.so')");
         execute_string(L, "parameter('not_existing')");
+
+        // Check that the CubaIndex() function returns the correct InputTag
+        // and that the index gets correctly incremented at each call.
+        execute_string(L, "index1 = CubaIndex()");
+        lua_getglobal(L.get(), "index1");
+        auto value = lua::to_any(L.get(), -1);
+        REQUIRE( (boost::any_cast<InputTag>(value.first)).toString() == "cuba::ps_points/0");
+        execute_string(L, "index2 = CubaIndex()");
+        lua_getglobal(L.get(), "index2");
+        value = lua::to_any(L.get(), -1);
+        REQUIRE( (boost::any_cast<InputTag>(value.first)).toString() == "cuba::ps_points/1");
+        lua_pop(L.get(), 2);
     }
 
     SECTION("defining modules") {


### PR DESCRIPTION
Instead of using `cuba::ps_point/i` as input tag in the config file, where the user has to be sure `i` is always correctly incremented and unique, introduce the function `CubaIndex()`, which always returns the correct input tag.

`examples/tt_fullyleptonic.lua` was modified to illustrate this behaviour.