### PR TITLE
Start indexing of InputTag at 1 like in Lua

### DIFF
--- a/core/src/InputTag.cc
+++ b/core/src/InputTag.cc
@@ -49,7 +49,7 @@ InputTag::InputTag(const std::string& module, const std::string& parameter):
 
 InputTag::InputTag(const std::string& module, const std::string& parameter, size_t index):
     module(module), parameter(parameter), index(index), indexed(true) {
-    string_representation = module + "::" + parameter + "/" + std::to_string(index);
+    string_representation = module + "::" + parameter + "/" + std::to_string(index + 1);
 }
 
 bool InputTag::isInputTag(const std::string& tag) {
@@ -60,8 +60,10 @@ bool InputTag::isInputTag(const std::string& tag) {
         auto tags = split(tag, "::");
         auto rtags = split(tags[1], "/");
         try {
-            size_t index = std::stoull(rtags[1]);
-            UNUSED(index);
+            int64_t index = std::stoll(rtags[1]) - 1;
+            if (index < 0)
+                return false;
+
             return true;
         } catch (std::invalid_argument e) {
             return false;
@@ -78,7 +80,7 @@ InputTag InputTag::fromString(const std::string& tag) {
     if (rtags.size() == 1)
         return InputTag(tags[0], tags[1]);
     else
-        return InputTag(tags[0], rtags[0], std::stoull(rtags[1]));
+        return InputTag(tags[0], rtags[0], std::stoull(rtags[1]) - 1);
 }
 
 bool InputTag::operator==(const InputTag& rhs) const {

--- a/core/src/lua/utils.cc
+++ b/core/src/lua/utils.cc
@@ -452,7 +452,7 @@ namespace lua {
 
         // Define the `getpspoint()` function in Lua and make it available in the global namespace.
         // See generate_cuba_inputtag for more information.
-        lua_pushnumber(L, 0);
+        lua_pushnumber(L, 1);
         lua_pushcclosure(L, generate_cuba_inputtag, 1);
         lua_setglobal(L, "getpspoint");
     }

--- a/examples/tt_fullyleptonic.lua
+++ b/examples/tt_fullyleptonic.lua
@@ -22,10 +22,10 @@ if USE_TF then
 else
     -- No transfer functions
     inputs_before_perm = {
-        'input::particles/0',
         'input::particles/1',
         'input::particles/2',
         'input::particles/3',
+        'input::particles/4',
     }
 end
 
@@ -35,9 +35,9 @@ if USE_PERM then
   -- Use permutator module to permutate input particles 0 and 2 using the MC
   inputs = {
     inputs_before_perm[1],
-    'permutator::output/0',
-    inputs_before_perm[3],
     'permutator::output/1',
+    inputs_before_perm[3],
+    'permutator::output/2',
   }
 else
   -- No permutation, take particles as they come
@@ -85,39 +85,39 @@ BreitWignerGenerator.flatter_s256 = {
 if USE_TF then
     GaussianTransferFunction.tf_p1 = {
         ps_point = getpspoint(),
-        reco_particle = 'input::particles/0',
+        reco_particle = 'input::particles/1',
         sigma = 0.05,
     }
 
     GaussianTransferFunction.tf_p2 = {
         ps_point = getpspoint(),
-        reco_particle = 'input::particles/1',
+        reco_particle = 'input::particles/2',
         sigma = 0.10,
     }
 
     -- Example for binned transfer function (only works on ingrid)
     -- BinnedTransferFunctionOnEnergy.tf_p2 = {
-    --     ps_point = 'cuba::ps_points/5',
-    --     reco_particle = 'input::particles/1',
+    --     ps_point = getpspoint(),
+    --     reco_particle = 'input::particles/2',
     --     file = '/home/fynu/swertz/tests_MEM/binnedTF/TF_generator/Control_plots_hh_TF.root',
     --     th2_name = 'Binned_Egen_DeltaE_Norm_jet',
     -- }
 
     GaussianTransferFunction.tf_p3 = {
         ps_point = getpspoint(),
-        reco_particle = 'input::particles/2',
+        reco_particle = 'input::particles/3',
         sigma = 0.05,
     }
 
     GaussianTransferFunction.tf_p4 = {
         ps_point = getpspoint(),
-        reco_particle = 'input::particles/3',
+        reco_particle = 'input::particles/4',
         sigma = 0.10,
     }
 
     -- BinnedTransferFunctionOnEnergy.tf_p4 = {
-    --     ps_point = 'cuba::ps_points/7',
-    --     reco_particle = 'input::particles/3',
+    --     ps_point = getpspoint(),
+    --     reco_particle = 'input::particles/4',
     --     file = '/home/fynu/swertz/tests_MEM/binnedTF/TF_generator/Control_plots_hh_TF.root',
     --     th2_name = 'Binned_Egen_DeltaE_Norm_jet',
     -- }

--- a/examples/tt_fullyleptonic_NWA.lua
+++ b/examples/tt_fullyleptonic_NWA.lua
@@ -9,9 +9,9 @@ inputs_before_perm = {
 -- Use permutator module to permutate input particles 0 and 2 using the MC
 inputs = {
   inputs_before_perm[1],
-  'permutator::output/0',
-  inputs_before_perm[3],
   'permutator::output/1',
+  inputs_before_perm[3],
+  'permutator::output/2',
 }
 
 parameters = {
@@ -48,32 +48,32 @@ NarrowWidthApproximation.nwa_s256 = {
 }
 
 GaussianTransferFunction.tf_p1 = {
-    ps_point = 'cuba::ps_points/0',
-    reco_particle = 'input::particles/0',
+    ps_point = 'cuba::ps_points/1',
+    reco_particle = 'input::particles/1',
     sigma = 0.05,
 }
 
 GaussianTransferFunction.tf_p2 = {
-    ps_point = 'cuba::ps_points/1',
-    reco_particle = 'input::particles/1',
+    ps_point = 'cuba::ps_points/2',
+    reco_particle = 'input::particles/2',
     sigma = 0.10,
 }
 
 GaussianTransferFunction.tf_p3 = {
-    ps_point = 'cuba::ps_points/2',
-    reco_particle = 'input::particles/2',
+    ps_point = 'cuba::ps_points/3',
+    reco_particle = 'input::particles/3',
     sigma = 0.05,
 }
 
 GaussianTransferFunction.tf_p4 = {
-    ps_point = 'cuba::ps_points/3',
-    reco_particle = 'input::particles/3',
+    ps_point = 'cuba::ps_points/4',
+    reco_particle = 'input::particles/4',
     sigma = 0.10,
 }
   
 Permutator.permutator = {
-    ps_point = 'cuba::ps_points/4',
-    input = {
+    ps_point = 'cuba::ps_points/5',
+    inputs = {
       inputs_before_perm[2],
       inputs_before_perm[4],
     }

--- a/modules/FlatTransferFunctionOnTheta.cc
+++ b/modules/FlatTransferFunctionOnTheta.cc
@@ -44,7 +44,7 @@
  *    - `output` (LorentzVector): Output "generated" LorentzVector, only differing from 'reco_particle' by its \f$\theta\f$.
  *    - `TF_times_jacobian` (double): Transfer function (ie, 1) times the jacobian (due to the integration range).
  *
- * \brief modules
+ * \ingroup modules
  */
 
 class FlatTransferFunctionOnTheta: public Module {

--- a/tests/crossSections/blockD_ttx_dilep.lua
+++ b/tests/crossSections/blockD_ttx_dilep.lua
@@ -20,63 +20,63 @@ cuba = {
 -- 'Flat' transfer functions to integrate over the visible particle's energies and angles
 -- First |P|
 FlatTransferFunctionOnP.tf_p_1 = {
-    ps_point = 'cuba::ps_points/0',
-    reco_particle = 'input::particles/0',
-    min = 0.,
-    max = configuration.energy/2,
-}
-FlatTransferFunctionOnP.tf_p_2 = {
-    ps_point = 'cuba::ps_points/1',
+    ps_point = getpspoint(),
     reco_particle = 'input::particles/1',
     min = 0.,
-    max = configuration.energy/2,
+    max = parameters.energy/2,
 }
-FlatTransferFunctionOnP.tf_p_3 = {
-    ps_point = 'cuba::ps_points/2',
+FlatTransferFunctionOnP.tf_p_2 = {
+    ps_point = getpspoint(),
     reco_particle = 'input::particles/2',
     min = 0.,
-    max = configuration.energy/2,
+    max = parameters.energy/2,
 }
-FlatTransferFunctionOnP.tf_p_4 = {
-    ps_point = 'cuba::ps_points/3',
+FlatTransferFunctionOnP.tf_p_3 = {
+    ps_point = getpspoint(),
     reco_particle = 'input::particles/3',
     min = 0.,
-    max = configuration.energy/2,
+    max = parameters.energy/2,
+}
+FlatTransferFunctionOnP.tf_p_4 = {
+    ps_point = getpspoint(),
+    reco_particle = 'input::particles/4',
+    min = 0.,
+    max = parameters.energy/2,
 }
 
 -- Pass these outputs over for Phi
 FlatTransferFunctionOnPhi.tf_phi_1 = {
-    ps_point = 'cuba::ps_points/4',
+    ps_point = getpspoint(),
     reco_particle = 'tf_p_1::output',
 }
 FlatTransferFunctionOnPhi.tf_phi_2 = {
-    ps_point = 'cuba::ps_points/5',
+    ps_point = getpspoint(),
     reco_particle = 'tf_p_2::output',
 }
 FlatTransferFunctionOnPhi.tf_phi_3 = {
-    ps_point = 'cuba::ps_points/6',
+    ps_point = getpspoint(),
     reco_particle = 'tf_p_3::output',
 }
 FlatTransferFunctionOnPhi.tf_phi_4 = {
-    ps_point = 'cuba::ps_points/7',
+    ps_point = getpspoint(),
     reco_particle = 'tf_p_4::output',
 }
 
 -- Finally, do Theta 
 FlatTransferFunctionOnTheta.tf_theta_1 = {
-    ps_point = 'cuba::ps_points/8',
+    ps_point = getpspoint(),
     reco_particle = 'tf_phi_1::output',
 }
 FlatTransferFunctionOnTheta.tf_theta_2 = {
-    ps_point = 'cuba::ps_points/9',
+    ps_point = getpspoint(),
     reco_particle = 'tf_phi_2::output',
 }
 FlatTransferFunctionOnTheta.tf_theta_3 = {
-    ps_point = 'cuba::ps_points/10',
+    ps_point = getpspoint(),
     reco_particle = 'tf_phi_3::output',
 }
 FlatTransferFunctionOnTheta.tf_theta_4 = {
-    ps_point = 'cuba::ps_points/11',
+    ps_point = getpspoint(),
     reco_particle = 'tf_phi_4::output',
 }
 
@@ -88,25 +88,25 @@ inputs = {
 }
 
 BreitWignerGenerator.flatter_s13 = {
-    ps_point = "cuba::ps_points/12",
+    ps_point = getpspoint(),
     mass = M_W,
     width = W_W
 }
 
 BreitWignerGenerator.flatter_s134 = {
-    ps_point = "cuba::ps_points/13",
+    ps_point = getpspoint(),
     mass = M_TOP,
     width = W_TOP
 }
 
 BreitWignerGenerator.flatter_s25 = {
-    ps_point = "cuba::ps_points/14",
+    ps_point = getpspoint(),
     mass = M_W,
     width = W_W
 }
 
 BreitWignerGenerator.flatter_s256 = {
-    ps_point = "cuba::ps_points/15",
+    ps_point = getpspoint(),
     mass = M_TOP,
     width = W_TOP
 }

--- a/tests/phaseSpaceVolume/blockD.lua
+++ b/tests/phaseSpaceVolume/blockD.lua
@@ -22,63 +22,63 @@ cuba = {
 -- 'Flat' transfer functions to integrate over the visible particle's energies and angles
 -- First |P|
 FlatTransferFunctionOnP.tf_p_1 = {
-    ps_point = 'cuba::ps_points/0',
-    reco_particle = 'input::particles/0',
-    min = 0.,
-    max = configuration.energy/2,
-}
-FlatTransferFunctionOnP.tf_p_2 = {
-    ps_point = 'cuba::ps_points/1',
+    ps_point = getpspoint(),
     reco_particle = 'input::particles/1',
     min = 0.,
-    max = configuration.energy/2,
+    max = parameters.energy/2,
 }
-FlatTransferFunctionOnP.tf_p_3 = {
-    ps_point = 'cuba::ps_points/2',
+FlatTransferFunctionOnP.tf_p_2 = {
+    ps_point = getpspoint(),
     reco_particle = 'input::particles/2',
     min = 0.,
-    max = configuration.energy/2,
+    max = parameters.energy/2,
 }
-FlatTransferFunctionOnP.tf_p_4 = {
-    ps_point = 'cuba::ps_points/3',
+FlatTransferFunctionOnP.tf_p_3 = {
+    ps_point = getpspoint(),
     reco_particle = 'input::particles/3',
     min = 0.,
-    max = configuration.energy/2,
+    max = parameters.energy/2,
+}
+FlatTransferFunctionOnP.tf_p_4 = {
+    ps_point = getpspoint(),
+    reco_particle = 'input::particles/4',
+    min = 0.,
+    max = parameters.energy/2,
 }
 
 -- Pass these outputs over for Phi
 FlatTransferFunctionOnPhi.tf_phi_1 = {
-    ps_point = 'cuba::ps_points/4',
+    ps_point = getpspoint(),
     reco_particle = 'tf_p_1::output',
 }
 FlatTransferFunctionOnPhi.tf_phi_2 = {
-    ps_point = 'cuba::ps_points/5',
+    ps_point = getpspoint(),
     reco_particle = 'tf_p_2::output',
 }
 FlatTransferFunctionOnPhi.tf_phi_3 = {
-    ps_point = 'cuba::ps_points/6',
+    ps_point = getpspoint(),
     reco_particle = 'tf_p_3::output',
 }
 FlatTransferFunctionOnPhi.tf_phi_4 = {
-    ps_point = 'cuba::ps_points/7',
+    ps_point = getpspoint(),
     reco_particle = 'tf_p_4::output',
 }
 
 -- Finally, do Theta 
 FlatTransferFunctionOnTheta.tf_theta_1 = {
-    ps_point = 'cuba::ps_points/8',
+    ps_point = getpspoint(),
     reco_particle = 'tf_phi_1::output',
 }
 FlatTransferFunctionOnTheta.tf_theta_2 = {
-    ps_point = 'cuba::ps_points/9',
+    ps_point = getpspoint(),
     reco_particle = 'tf_phi_2::output',
 }
 FlatTransferFunctionOnTheta.tf_theta_3 = {
-    ps_point = 'cuba::ps_points/10',
+    ps_point = getpspoint(),
     reco_particle = 'tf_phi_3::output',
 }
 FlatTransferFunctionOnTheta.tf_theta_4 = {
-    ps_point = 'cuba::ps_points/11',
+    ps_point = getpspoint(),
     reco_particle = 'tf_phi_4::output',
 }
 
@@ -90,25 +90,25 @@ inputs = {
 }
 
 BreitWignerGenerator.flatter_s13 = {
-    ps_point = "cuba::ps_points/12",
+    ps_point = getpspoint(),
     mass = M_W,
     width = W_W
 }
 
 BreitWignerGenerator.flatter_s134 = {
-    ps_point = "cuba::ps_points/13",
+    ps_point = getpspoint(),
     mass = M_TOP,
     width = W_TOP
 }
 
 BreitWignerGenerator.flatter_s25 = {
-    ps_point = "cuba::ps_points/14",
+    ps_point = getpspoint(),
     mass = M_W,
     width = W_W
 }
 
 BreitWignerGenerator.flatter_s256 = {
-    ps_point = "cuba::ps_points/15",
+    ps_point = getpspoint(),
     mass = M_TOP,
     width = W_TOP
 }

--- a/tests/unit_tests/lua.cc
+++ b/tests/unit_tests/lua.cc
@@ -70,11 +70,11 @@ TEST_CASE("lua parsing utilities", "[lua]") {
         execute_string(L, "index1 = getpspoint()");
         lua_getglobal(L.get(), "index1");
         auto value = lua::to_any(L.get(), -1);
-        REQUIRE( (boost::any_cast<InputTag>(value.first)).toString() == "cuba::ps_points/0");
+        REQUIRE( (boost::any_cast<InputTag>(value.first)).toString() == "cuba::ps_points/1");
         execute_string(L, "index2 = getpspoint()");
         lua_getglobal(L.get(), "index2");
         value = lua::to_any(L.get(), -1);
-        REQUIRE( (boost::any_cast<InputTag>(value.first)).toString() == "cuba::ps_points/1");
+        REQUIRE( (boost::any_cast<InputTag>(value.first)).toString() == "cuba::ps_points/2");
         lua_pop(L.get(), 2);
     }
 


### PR DESCRIPTION
In Lua, array indexing starts at 1, and not 0 like C++. In order to be consistent, the InputTag indexing is changed to also starts at 1 instead of 0.

I've updated all the configuration file, but a second look is appreciate to be sure I did not miss anything.

I also documented the InputTag class.