### PR TITLE
Add preliminary support for DMEM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ set(MOMEMTA_SOURCES
     "modules/BlockF.cc"
     "modules/Boost.cc"
     "modules/BreitWignerGenerator.cc"
+    "modules/DMEM.cc"
     "modules/FlatTransferFunctionOnP.cc"
     "modules/FlatTransferFunctionOnPhi.cc"
     "modules/FlatTransferFunctionOnTheta.cc"

--- a/core/src/Graph.cc
+++ b/core/src/Graph.cc
@@ -62,11 +62,11 @@ Graph build(const Pool::DescriptionMap& description, std::vector<ModulePtr>& mod
     }
 
     // Find any module whose output is not used by any module. It's useless, so remove it
-    // Only allowed module in this situation is virtual modules.
+    // Only allowed module in this situation is virtual modules, or modules whose leafModule() method returns true.
     for (auto it = vertices.begin(), ite = vertices.end(); it != ite;) {
         if (boost::out_degree(it->second, g) == 0) {
 
-            if (Module::is_virtual_module(it->first)) {
+            if (Module::is_virtual_module(it->first) || g[it->second].module->leafModule()) {
                 ++it;
                 continue;
             }

--- a/core/src/Pool.cc
+++ b/core/src/Pool.cc
@@ -16,7 +16,6 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #include <momemta/Pool.h>
 #include <logging.h>
 
@@ -76,6 +75,11 @@ void Pool::alias(const InputTag& from, const InputTag& to) {
         throw duplicated_tag_error("A module already produced the tag '" + to.toString() + "'");
 
     m_storage[to] = m_storage[from];
+}
+
+bool Pool::exists(const InputTag& tag) const {
+    auto it = m_storage.find(tag);
+    return it != m_storage.end();
 }
 
 void Pool::current_module(const std::string& module) {

--- a/examples/tt_fullyleptonic.cc
+++ b/examples/tt_fullyleptonic.cc
@@ -21,6 +21,8 @@
 #include <momemta/MoMEMta.h>
 #include <momemta/Utils.h>
 
+#include <TH1D.h>
+
 #include <chrono>
 
 using namespace std::chrono;
@@ -56,6 +58,10 @@ int main(int argc, char** argv) {
     for (const auto& r: weights) {
         LOG(debug) << r.first << " +- " << r.second;
     }
+    
+    LOG(debug) << "Hist in pool: " << weight.getPool().exists({"dmem_ttbar", "hist"});
+    std::shared_ptr<const TH1D> dmem = weight.getPool().get<TH1D>({"dmem_ttbar", "hist"});
+    LOG(debug) << "DMEM integral: " << dmem->Integral();
 
     LOG(info) << "Weight computed in " << std::chrono::duration_cast<milliseconds>(end_time - start_time).count() << "ms";
 

--- a/examples/tt_fullyleptonic.lua
+++ b/examples/tt_fullyleptonic.lua
@@ -53,6 +53,7 @@ parameters = {
 }
 
 cuba = {
+    relative_accuracy = 0.01,
     verbosity = 3
 }
 
@@ -210,3 +211,14 @@ MatrixElement.ttbar = {
 
   jacobians = jacobians
 }
+
+DMEM.dmem_ttbar = {
+  x_start = 0.,
+  x_end = 2000.,
+  n_bins = 500,
+  ps_weight = 'cuba::ps_weight',
+  particles = inputs,
+  invisibles = 'blockd::invisibles',
+  integrands = 'ttbar::integrands',
+}
+

--- a/include/momemta/MoMEMta.h
+++ b/include/momemta/MoMEMta.h
@@ -40,8 +40,13 @@ class MoMEMta {
 
         double integrand(const double* psPoints, const double* weights);
 
+        const Pool& getPool() const;
 
     private:
+        class integrands_output_error: public std::runtime_error {
+            using std::runtime_error::runtime_error;
+        };
+
         static int CUBAIntegrand(const int *nDim, const double* psPoint, const int *nComp, double *value, void *inputs, const int *nVec, const int *core, const double *weight);
 
         PoolPtr m_pool;
@@ -55,6 +60,7 @@ class MoMEMta {
 
         // Pool inputs
         std::shared_ptr<std::vector<double>> m_ps_points;
+        std::shared_ptr<double> m_ps_weight;
         std::shared_ptr<std::vector<LorentzVector>> m_particles;
         std::shared_ptr<const std::vector<double>> m_integrands;
 };

--- a/modules/DMEM.cc
+++ b/modules/DMEM.cc
@@ -1,0 +1,105 @@
+/*
+ *  MoMEMta: a modular implementation of the Matrix Element Method
+ *  Copyright (C) 2016  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <TH1D.h>
+
+#include <momemta/ParameterSet.h>
+#include <momemta/Module.h>
+
+/*
+ * \brief Module implementing the Differential MEM
+ *
+ * \ingroup modules
+ */
+
+class DMEM: public Module {
+    public:
+
+        DMEM(PoolPtr pool, const ParameterSet& parameters): Module(pool, parameters.getModuleName())
+        {
+            x_start = parameters.get<double>("x_start");
+            x_end = parameters.get<double>("x_end");
+            n_bins = parameters.get<int64_t>("n_bins");
+
+            m_hist = produce<TH1D>("hist", (name() + "_DMEM").c_str(), (name() + "_DMEM").c_str(), n_bins, x_start, x_end);
+            m_hist->SetDirectory(0);
+
+            m_particle_tags = parameters.get<std::vector<InputTag>>("particles");
+            for (auto& t: m_particle_tags)
+              t.resolve(pool);
+            
+            InputTag invisibles_tag = parameters.get<InputTag>("invisibles");
+            m_invisibles = get<std::vector<std::vector<LorentzVector>>>(invisibles_tag);
+
+            psWeight = get<double>(parameters.get<InputTag>("ps_weight"));
+            integrands = get<std::vector<double>>(parameters.get<InputTag>("integrands"));
+        }
+
+        virtual void beginIntegration() override {
+            m_hist->Reset();
+        }
+
+        virtual void work() override {
+            
+            LorentzVector tot;
+            for(const auto &v: m_particle_tags)
+                tot += v.get<LorentzVector>();
+
+            // No invisibles -> loop over particles we got as input
+            if(!m_invisibles.get() || m_invisibles->empty()) {
+                
+                m_hist->Fill(tot.M(), (*integrands)[0] * (*psWeight));
+            
+            } else {
+        
+                // Several solutions for the invisibles -> loop over all solution,
+                // fill histogram with corresponding integrand.
+                for(size_t sol = 0; sol < m_invisibles->size(); sol++) {
+                    LorentzVector thisTot = tot;
+                    
+                    for(const auto &v: (*m_invisibles)[sol])
+                      thisTot += v;
+
+                    m_hist->Fill(thisTot.M(), (*integrands)[sol] * (*psWeight));
+                }
+
+            }
+        }
+
+        virtual size_t dimensions() const override {
+            return 0;
+        }
+
+        virtual bool leafModule() const override {
+            return true;
+        }
+
+    private:
+
+        double x_start, x_end;
+        int64_t n_bins;
+        
+        std::vector<InputTag> m_particle_tags;
+        std::shared_ptr<const std::vector<std::vector<LorentzVector>>> m_invisibles;
+        
+        std::shared_ptr<const double> psWeight;
+        std::shared_ptr<const std::vector<double>> integrands;
+        
+        std::shared_ptr<TH1D> m_hist;
+};
+REGISTER_MODULE(DMEM);


### PR DESCRIPTION
Make some changes to make things such as DMEM possible:
- Add virtual method `leafModule` to the `Module` class, to flag modules whose products are not used as input to any other module: when the graph is built, do not remove modules which return `true`.
- The module producing the integrand doesn't have to be the last module in the config file anymore: the output `integrands` is now reserved for this purpose (as a consequence, if no module, or more than one module produces it, it is an error).
- Add the "virtual" input tag `cuba::ps_weight` to have access the the phase space point's weight.
- `Pool::put` is now templated to allow calling any constructor for objects stored in the pool.
- Add the method `MoMEMta::getPool` to allow the user to retrieve objects in the pool after the integration is over.
- Add the virtual methods `atBeginIntegration` and `atEndIntegration` to the `Module` class, to be called right before or after the integration for each event.
- Add the DMEM module, which does... DMEM, for total invariant mass only... I'm not sure if we can avoid defining a module for every variable we want to plot...

I added a little bit to the example for tt to show how to use the new DMEM module. 

I still want to add some more documentation, check that the output distributions are correct, and maybe rename things to more explicit. Until then, comments are welcome!