### PR TITLE
Move initial partons from vector to pair

### DIFF
--- a/MatrixElements/dummy/dummy_me.cc
+++ b/MatrixElements/dummy/dummy_me.cc
@@ -12,7 +12,7 @@ class DummyMatrixElement : public momemta::MatrixElement {
 
     // Calculate flavour-independent parts of cross section.
     virtual momemta::MatrixElement::Result
-    compute(const std::vector<std::vector<double>>& initialMomenta,
+    compute(const std::pair<std::vector<double>, std::vector<double>>& initialMomenta,
             const std::vector<std::pair<int, std::vector<double>>>& finalState) {
         UNUSED(initialMomenta);
         UNUSED(finalState);

--- a/MatrixElements/pp_ttx_fully_leptonic/SubProcesses/P1_Sigma_sm_gg_mupvmbmumvmxbx/cpp_pp_ttx_fullylept.cc
+++ b/MatrixElements/pp_ttx_fully_leptonic/SubProcesses/P1_Sigma_sm_gg_mupvmbmumvmxbx/cpp_pp_ttx_fullylept.cc
@@ -250,14 +250,14 @@ cpp_pp_ttx_fullylept::cpp_pp_ttx_fullylept(const ParameterSet& configuration) {
 // Evaluate |M|^2, return a map of final states
 
 std::map < std::pair < int, int > , double >
-    cpp_pp_ttx_fullylept::compute(const std::vector < std::vector<double> >
+    cpp_pp_ttx_fullylept::compute(const std::pair < std::vector<double>, std::vector<double> >
     &initialMomenta, const std::vector < std::pair < int, std::vector<double> >
     > &finalState)
 {
 
   // Set initial particle momenta
-  momenta[0] = (double * ) (&initialMomenta[0][0]); 
-  momenta[1] = (double * ) (&initialMomenta[1][0]); 
+  momenta[0] = (double * ) (&initialMomenta.first[0]); 
+  momenta[1] = (double * ) (&initialMomenta.second[0]); 
 
   // Suppose final particles are passed in the "correct" order
   std::vector<int> selectedFinalState(8 - 2); 

--- a/MatrixElements/pp_ttx_fully_leptonic/SubProcesses/P1_Sigma_sm_gg_mupvmbmumvmxbx/cpp_pp_ttx_fullylept.h
+++ b/MatrixElements/pp_ttx_fully_leptonic/SubProcesses/P1_Sigma_sm_gg_mupvmbmumvmxbx/cpp_pp_ttx_fullylept.h
@@ -132,7 +132,7 @@
 
       // Calculate flavour-independent parts of cross section.
       virtual momemta::MatrixElement::Result compute(const
-          std::vector < std::vector<double> > &initialMomenta, const
+          std::pair < std::vector<double>, std::vector<double> > &initialMomenta, const
           std::vector < std::pair < int, std::vector<double> > > &finalState);
 
       virtual std::shared_ptr<momemta::MEParameters> getParameters() {

--- a/include/momemta/MatrixElement.h
+++ b/include/momemta/MatrixElement.h
@@ -22,6 +22,7 @@
 #define MOMEMTA_MATRIXELEMENT_H
 
 #include <map>
+#include <utility>
 #include <memory>
 #include <string>
 #include <vector>
@@ -39,7 +40,7 @@ namespace momemta {
             virtual ~MatrixElement() {};
     
             virtual Result compute(
-                    const std::vector<std::vector<double>>& initialMomenta,
+                    const std::pair<std::vector<double>, std::vector<double>>& initialMomenta,
                     const std::vector<std::pair<int, std::vector<double>>>& finalState
                     ) = 0;
 

--- a/modules/MatrixElement.cc
+++ b/modules/MatrixElement.cc
@@ -153,10 +153,7 @@ class MatrixElement: public Module {
             auto permutations = get_permutations(suite, indexing);
             apply_permutations(finalStates, permutations);
 
-            std::vector<std::vector<double>> initialState(partons.size());
-            size_t index = 0;
-            for (const auto& parton: partons)
-                initialState[index++] = toVector(parton);
+            std::pair<std::vector<double>, std::vector<double>> initialState { toVector(partons[0]), toVector(partons[1]) };
 
             auto result = m_ME->compute(initialState, finalStates);
 


### PR DESCRIPTION
To be inline with the matrix element exporter, move the intial parton object passed to the ME from a vector of 4-vectors to a pair of 4-vectors.