### PR TITLE
Allow creation of non-existing parameters

### DIFF
--- a/core/include/lua/utils.h
+++ b/core/include/lua/utils.h
@@ -98,6 +98,11 @@ namespace lua {
         virtual boost::any operator() () const override;
 
         /**
+         * \brief Ensure the global table referenced by this `struct` exist. If not, create it.
+         */
+        void ensure_created();
+
+        /**
          * \brief Replace the value of the table field by a new one
          */
         void set(const boost::any& value);

--- a/core/src/ConfigurationReader.cc
+++ b/core/src/ConfigurationReader.cc
@@ -43,7 +43,7 @@ ConfigurationReader::ConfigurationReader(const std::string& file) {
     // FIXME: Find a better way of doing that
 
     // Read global parameters from global variable named 'configuration'
-    m_global_parameters.reset(new LazyParameterSet("parameters"));
+    m_global_parameters.reset(new LazyParameterSet(lua_state, "parameters"));
     int type = lua_getglobal(lua_state.get(), "parameters");
     if (type == LUA_TTABLE) {
         LOG(debug) << "Parsing global parameters.";
@@ -52,7 +52,7 @@ ConfigurationReader::ConfigurationReader(const std::string& file) {
     lua_pop(lua_state.get(), 1);
 
     // Read cuba configuration
-    m_cuba_configuration.reset(new LazyParameterSet("cuba"));
+    m_cuba_configuration.reset(new LazyParameterSet(lua_state, "cuba"));
     type = lua_getglobal(lua_state.get(), "cuba");
     if (type == LUA_TTABLE) {
         LOG(debug) << "Parsing cuba configuration.";

--- a/core/src/lua/utils.cc
+++ b/core/src/lua/utils.cc
@@ -331,6 +331,9 @@ namespace lua {
         } else if (value.type() == typeid(std::string)) {
             auto v = boost::any_cast<std::string>(value);
             lua_pushstring(L, v.c_str());
+        } else if (value.type() == typeid(InputTag)) {
+            auto v = boost::any_cast<InputTag>(value).toString();
+            lua_pushstring(L, v.c_str());
         } else {
             LOG(fatal) << "Unsupported C++ value: " << demangle(value.type().name());
             throw lua::unsupported_type_error(demangle(value.type().name()));

--- a/core/src/lua/utils.cc
+++ b/core/src/lua/utils.cc
@@ -75,6 +75,22 @@ namespace lua {
         this->key = key;
     }
 
+    void LazyTableField::ensure_created() {
+        // Push the table on the stack. Stack +1
+        int type = lua_getglobal(L, table_name.c_str());
+        // Discard the result. Stack -1
+        lua_pop(L, 1);
+
+        // Already existing
+        if (type != LUA_TNIL)
+            return;
+
+        // Create a new table. Stack +1
+        lua_newtable(L);
+        // Set it global. Stack -1
+        lua_setglobal(L, table_name.c_str());
+    }
+
     boost::any LazyTableField::operator() () const {
         LOG(trace) << "[LazyTableField::operator()] >> stack size = " << lua_gettop(L);
 

--- a/include/momemta/ParameterSet.h
+++ b/include/momemta/ParameterSet.h
@@ -282,10 +282,10 @@ class lua_State;
 
 class LazyParameterSet: public ParameterSet {
     friend class ConfigurationReader;
-
-    protected:
+    public:
         LazyParameterSet(std::shared_ptr<lua_State> L, const std::string& name);
 
+    protected:
         virtual std::pair<boost::any, bool> parseItem(const std::string& key, lua_State* L, int index) override;
 
         virtual void create(const std::string& name, const boost::any& value) override;

--- a/include/momemta/impl/traits.h
+++ b/include/momemta/impl/traits.h
@@ -1,0 +1,29 @@
+/*
+ *  MoMEMta: a modular implementation of the Matrix Element Method
+ *  Copyright (C) 2016  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string>
+#include <type_traits>
+
+template <typename T>
+struct is_string: public std::integral_constant<bool,
+        std::is_same<      char *, typename std::decay<T>::type>::value ||
+        std::is_same<const char *, typename std::decay<T>::type>::value
+     > {};
+
+template <>
+struct is_string<std::string>: std::true_type {};

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     "lua.cc"
+    "ParameterSet.cc"
     "unit_tests.cc"
     )
 

--- a/tests/unit_tests/ParameterSet.cc
+++ b/tests/unit_tests/ParameterSet.cc
@@ -1,0 +1,78 @@
+/*
+ *  MoMEMta: a modular implementation of the Matrix Element Method
+ *  Copyright (C) 2016  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ * \brief Unit tests for ParameterSet
+ * \ingroup UnitTests
+ */
+
+#include <catch.hpp>
+
+#include <momemta/InputTag.h>
+#include <momemta/ParameterSet.h>
+
+TEST_CASE("ParameterSet unit tests", "[core]") {
+    ParameterSet p;
+
+    SECTION("Adding bool") {
+        REQUIRE_FALSE(p.existsAs<bool>("parameter"));
+
+        p.set("parameter", false);
+
+        REQUIRE(p.existsAs<bool>("parameter"));
+        REQUIRE_FALSE(p.get<bool>("parameter"));
+    }
+
+    SECTION("Adding string") {
+        REQUIRE_FALSE(p.existsAs<std::string>("parameter"));
+
+        p.set("parameter", "test");
+
+        REQUIRE(p.existsAs<std::string>("parameter"));
+        REQUIRE(p.get<std::string>("parameter") == "test");
+    }
+
+    SECTION("Adding InputTag") {
+        REQUIRE_FALSE(p.existsAs<InputTag>("parameter"));
+
+        auto v = InputTag("module_name", "parameter");
+        p.set("parameter", v);
+
+        REQUIRE(p.existsAs<InputTag>("parameter"));
+        REQUIRE(p.get<InputTag>("parameter") == v);
+    }
+
+    SECTION("Implicit int64_t cast") {
+        REQUIRE_FALSE(p.existsAs<int64_t>("parameter"));
+
+        p.set("parameter", 10);
+
+        REQUIRE(p.existsAs<int64_t>("parameter"));
+        REQUIRE(p.get<int64_t>("parameter") == 10);
+    }
+
+    SECTION("Implicit double cast") {
+        REQUIRE_FALSE(p.existsAs<double>("parameter"));
+
+        p.set("parameter", 10.f);
+
+        REQUIRE(p.existsAs<double>("parameter"));
+        REQUIRE(p.get<double>("parameter") == Approx(10));
+    }
+}


### PR DESCRIPTION
It's currently not possible to set or edit a parameter if it was not previously declared in the lua configuration file. For example, if the cuba verbosity is not defined in lua, it's not possible to change its value in C++.

With this PR, it's now possible to edit a parameter, even if it does not exist:
 - If the associated lua table does not exist, it's created first
 - The value of the parameter is changed directly in the lua side for `LazyParameterSet`, or simply in the map for `ParameterSet`

I've also simplified the `ParameterSet::set` method to perform implicit cast:
 - integral type to `int64_t`
 - floating point type to `double`

Previously, it was necessary to do explicit casting when doing for example 

```cpp
ParameterSet::set("value", (int64_t) 10);
```

There's also unit tests for the whole `ParameterSet` class.

--

See https://trello.com/c/Ej5PT07x for associated trello card