### PR TITLE
Push code coverage to coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
       - graphviz
 before_install:
   - ./travis/decrypt_key.sh 
+  - pip install --user cpp-coveralls
 install:
   - export CXX=g++-4.9
   - export CC=gcc-4.9
@@ -31,8 +32,9 @@ before_script:
   - export CC=gcc-4.9
   - mkdir build
   - cd build
-  - cmake .. -DTESTS=ON
+  - cmake .. -DTESTS=ON -DCOVERAGE=ON -DCMAKE_BUILD_TYPE=Debug
 script:
   - make -j2 && ./tests/unit_tests/unit_tests.exe
 after_success:
+  - if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then coveralls -e 'external/' --gcov-options '\-lp' -E '.*CMakeCXXCompilerId\.cpp' -E '.*CMakeCCompilerId\.c' -E '.*feature_tests\.c.*' -r .. &> /dev/null; fi
   - if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then ./make_docs.sh; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ if (PROFILING)
     endif()
 endif()
 
+option(COVERAGE "Enable code coverage" OFF)
+
 # Set a default build type for single-configuration
 # CMake generators if no build type is set.
 if (NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
@@ -45,6 +47,11 @@ endif(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 # Default compiler flags
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -pedantic -Wextra --std=c++11 -fcx-fortran-rules -fcx-limited-range")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fomit-frame-pointer -ffast-math -Wall --std=c11")
+
+if (COVERAGE)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
+endif()
 
 # If profiling, always include debug information
 if (PROFILING)


### PR DESCRIPTION
Since we are starting to have some unit tests coverage with #56, I figured out it'd be nice to have some tracking and display on how many code lines are covered by unit tests. For that, there's the free service named [coverall.io](https://coveralls.io). Once merged, travis will start generating code coverage metrics, and push them to coveralls. We'll then be able to see the percentage of code covered by unit tests (spoiler alert, it's about 30% with #56, we can do better :)) and keep track across time.