### PR TITLE
Do not hardcode PDF renormalization scale

### DIFF
--- a/examples/tt_fullyleptonic.lua
+++ b/examples/tt_fullyleptonic.lua
@@ -164,6 +164,7 @@ end
 
 MatrixElement.ttbar = {
   pdf = 'CT10nlo',
+  pdf_scale = parameter('top_mass'),
 
   matrix_element = 'pp_ttx_fully_leptonic',
   matrix_element_parameters = {

--- a/examples/tt_fullyleptonic_NWA.lua
+++ b/examples/tt_fullyleptonic_NWA.lua
@@ -104,6 +104,7 @@ jacobians = {
 
 MatrixElement.ttbar = {
   pdf = 'CT10nlo',
+  pdf_scale = parameter('top_mass'),
 
   matrix_element = 'pp_ttx_fully_leptonic',
   matrix_element_parameters = {

--- a/tests/crossSections/blockD_ttx_dilep.lua
+++ b/tests/crossSections/blockD_ttx_dilep.lua
@@ -137,6 +137,7 @@ jacobians = {
 
 MatrixElement.dummy = {
   pdf = 'CT10nlo',
+  pdf_scale = parameter('top_mass'),
 
   matrix_element = 'pp_ttx_fully_leptonic',
   matrix_element_parameters = {


### PR DESCRIPTION
Currently the PDF scale is hardcoded to the top mass. This PR adds a new mandatory input to the `MatrixElement` module for defining the renormalization scale used for the PDF.