### PR TITLE
Move math functions from Utils.h to Math.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ set(MOMEMTA_SOURCES
     "core/src/InputTag.cc"
     "core/src/LibraryManager.cc"
     "core/src/logging.cc"
+    "core/src/Math.cc"
     "core/src/MatrixElementFactory.cc"
     "core/src/MoMEMta.cc"
     "core/src/ModuleFactory.cc"

--- a/MatrixElements/dummy/dummy_me.cc
+++ b/MatrixElements/dummy/dummy_me.cc
@@ -1,5 +1,5 @@
 #include <momemta/MatrixElement.h>
-#include <momemta/Utils.h>
+#include <momemta/Unused.h>
 
 class DummyMatrixElement : public momemta::MatrixElement {
   public:

--- a/core/src/Math.cc
+++ b/core/src/Math.cc
@@ -1,0 +1,393 @@
+/*
+ *  MoMEMta: a modular implementation of the Matrix Element Method
+ *  Copyright (C) 2016  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <momemta/Math.h>
+
+#include <iostream>
+
+using namespace std;
+
+bool solveQuadratic(const double a, const double b, const double c, std::vector<double>& roots,
+                    bool verbose) {
+
+    if (!a) {
+        if (!b) {
+            cout << "No solution to equation " << a << " x^2 + " << b << " x + " << c << endl
+                 << endl;
+            return false;
+        }
+        roots.push_back(-c / b);
+        if (verbose)
+            cout << "Solution of " << b << " x + " << c << ": " << roots[0]
+                 << ", test = " << b * roots[0] + c << endl
+                 << endl;
+        return true;
+    }
+
+    const double rho = SQ(b) - 4. * a * c;
+
+    if (rho >= 0.) {
+        if (b == 0.) {
+            roots.push_back(sqrt(rho) / (2. * a));
+            roots.push_back(-sqrt(rho) / (2. * a));
+        } else {
+            const double x = -0.5 * (b + sign(b) * sqrt(rho));
+            roots.push_back(x / a);
+            roots.push_back(c / x);
+        }
+        if (verbose) {
+            cout << "Solutions of " << a << " x^2 + " << b << " x + " << c << ":" << endl;
+            for (unsigned short i = 0; i < roots.size(); i++)
+                cout << "x" << i << " = " << roots[i]
+                     << ", test = " << a * SQ(roots[i]) + b * roots[i] + c << endl;
+            cout << endl;
+        }
+        return true;
+    } else {
+        if (verbose)
+            cout << "No real solutions to " << a << " x^2 + " << b << " x + " << c << endl << endl;
+        return false;
+    }
+}
+
+bool solveCubic(const double a, const double b, const double c, const double d,
+                std::vector<double>& roots, bool verbose) {
+
+    if (a == 0)
+        return solveQuadratic(b, c, d, roots, verbose);
+
+    const double an = b / a;
+    const double bn = c / a;
+    const double cn = d / a;
+
+    const double Q = SQ(an) / 9. - bn / 3.;
+    const double R = CB(an) / 27. - an * bn / 6. + cn / 2.;
+
+    if (SQ(R) < CB(Q)) {
+        const double theta = acos(R / sqrt(CB(Q))) / 3.;
+
+        roots.push_back(-2. * sqrt(Q) * cos(theta) - an / 3.);
+        roots.push_back(-2. * sqrt(Q) * cosXpm2PI3(theta, 1.) - an / 3.);
+        roots.push_back(-2. * sqrt(Q) * cosXpm2PI3(theta, -1.) - an / 3.);
+    } else {
+        const double A = -sign(R) * cbrt(abs(R) + sqrt(SQ(R) - CB(Q)));
+
+        double B;
+
+        if (A == 0.)
+            B = 0.;
+        else
+            B = Q / A;
+
+        const double x = A + B - an / 3.;
+
+        roots.push_back(x);
+        roots.push_back(x);
+        roots.push_back(x);
+    }
+
+    if (verbose) {
+        cout << "Solutions of " << a << " x^3 + " << b << " x^2 + " << c << " x + " << d << ":"
+             << endl;
+        for (unsigned short i = 0; i < roots.size(); i++)
+            cout << "x" << i << " = " << roots[i]
+                 << ", test = " << a * CB(roots[i]) + b * SQ(roots[i]) + c * roots[i] + d << endl;
+        cout << endl;
+    }
+
+    return true;
+}
+
+bool solveQuartic(const double a, const double b, const double c, const double d, const double e,
+                  std::vector<double>& roots, bool verbose) {
+
+    if (!a)
+        return solveCubic(b, c, d, e, roots, verbose);
+
+    if (!b && !c && !d) {
+        roots.push_back(0.);
+        roots.push_back(0.);
+        roots.push_back(0.);
+        roots.push_back(0.);
+    } else {
+        const double an = b / a;
+        const double bn = c / a - (3. / 8.) * SQ(b / a);
+        const double cn = CB(0.5 * b / a) - 0.5 * b * c / SQ(a) + d / a;
+        const double dn =
+                -3. * QU(0.25 * b / a) + e / a - 0.25 * b * d / SQ(a) + c * SQ(b / 4.) / CB(a);
+
+        std::vector<double> res;
+        solveCubic(1., 2. * bn, SQ(bn) - 4. * dn, -SQ(cn), res, verbose);
+        short pChoice = -1;
+
+        for (unsigned short i = 0; i < res.size(); ++i) {
+            if (res[i] > 0) {
+                pChoice = i;
+                break;
+            }
+        }
+
+        if (pChoice < 0) {
+            if (verbose)
+                cout << "No real solution to " << a << " x^4 + " << b << " x^3 + " << c << " x^2 + "
+                     << d << " x + " << e << " (no positive root for the resolvent cubic)." << endl
+                     << endl;
+            return false;
+        }
+
+        const double p = sqrt(res[pChoice]);
+        solveQuadratic(p, SQ(p), 0.5 * (p * (bn + res[pChoice]) - cn), roots, verbose);
+        solveQuadratic(p, -SQ(p), 0.5 * (p * (bn + res[pChoice]) + cn), roots, verbose);
+
+        for (unsigned short i = 0; i < roots.size(); ++i)
+            roots[i] -= an / 4.;
+    }
+
+    size_t nRoots = roots.size();
+
+    if (verbose) {
+        if (nRoots) {
+            cout << "Solutions of " << a << " x^4 + " << b << " x^3 + " << c << " x^2 + " << d
+                 << " x + " << e << ":" << endl;
+            for (unsigned short i = 0; i < nRoots; i++)
+                cout << "x" << i << " = " << roots[i] << ", test = "
+                     << a * QU(roots[i]) + b * CB(roots[i]) + c * SQ(roots[i]) + d * roots[i] + e
+                     << endl;
+            cout << endl;
+        } else {
+            cout << "No real solution to " << a << " x^4 + " << b << " x^3 + " << c << " x^2 + "
+                 << d << " x + " << e << endl
+                 << endl;
+        }
+    }
+
+    return nRoots > 0;
+}
+
+bool solve2Quads(const double a20, const double a02, const double a11, const double a10,
+                 const double a01, const double a00, const double b20, const double b02,
+                 const double b11, const double b10, const double b01, const double b00,
+                 std::vector<double>& E1, std::vector<double>& E2, bool verbose) {
+
+    // The procedure used in this function relies on a20 != 0 or b20 != 0
+    if (a20 == 0. && b20 == 0.) {
+
+        if (a02 != 0. || b02 != 0.) {
+            // Swapping E1 <-> E2 should suffice!
+            return solve2Quads(a02, a20, a11, a01, a10, a00, b02, b20, b11, b01, b10, b00, E2, E1,
+                               verbose);
+        } else {
+            return solve2QuadsDeg(a11, a10, a01, a00, b11, b10, b01, b00, E1, E2, verbose);
+        }
+    }
+
+    const double alpha = b20 * a02 - a20 * b02;
+    const double beta = b20 * a11 - a20 * b11;
+    const double gamma = b20 * a10 - a20 * b10;
+    const double delta = b20 * a01 - a20 * b01;
+    const double omega = b20 * a00 - a20 * b00;
+
+    const double a = a20 * SQ(alpha) + a02 * SQ(beta) - a11 * alpha * beta;
+    const double b = 2. * a20 * alpha * delta - a11 * (alpha * gamma + delta * beta) -
+                     a10 * alpha * beta + 2. * a02 * beta * gamma + a01 * SQ(beta);
+    const double c = a20 * SQ(delta) + 2. * a20 * alpha * omega -
+                     a11 * (delta * gamma + omega * beta) - a10 * (alpha * gamma + delta * beta) +
+                     a02 * SQ(gamma) + 2. * a01 * beta * gamma + a00 * SQ(beta);
+    const double d = 2. * a20 * delta * omega - a11 * omega * gamma -
+                     a10 * (delta * gamma + omega * beta) + a01 * SQ(gamma) +
+                     2. * a00 * beta * gamma;
+    const double e = a20 * SQ(omega) - a10 * omega * gamma + a00 * SQ(gamma);
+
+    solveQuartic(a, b, c, d, e, E2, verbose);
+
+    for (unsigned short i = 0; i < E2.size(); ++i) {
+
+        const double e2 = E2[i];
+
+        if (beta * e2 + gamma != 0.) {
+            // Everything OK
+
+            const double e1 = -(alpha * SQ(e2) + delta * e2 + omega) / (beta * e2 + gamma);
+            E1.push_back(e1);
+
+        } else if (alpha * SQ(e2) + delta * e2 + omega == 0.) {
+            // Up to two solutions for e1
+
+            std::vector<double> e1;
+
+            if (!solveQuadratic(a20, a11 * e2 + a10, a02 * SQ(e2) + a01 * e2 + a00, e1, verbose)) {
+
+                if (!solveQuadratic(b20, b11 * e2 + b10, b02 * SQ(e2) + b01 * e2 + b00, e1,
+                                    verbose)) {
+                    cout << "Error in solve2Quads: there should be at least one solution for e1!"
+                         << endl;
+                    E1.clear();
+                    E2.clear();
+                    return false;
+                }
+
+            } else {
+                // We have either a double, or two roots for e1
+                // In this case, e2 must be twice degenerate!
+                // Since in E2 degenerate roots are grouped, E2[i+1] shoud exist and be equal to e2
+                // We then go straight for i+2.
+
+                if (i < E2.size() - 1) {
+
+                    if (e2 != E2[i + 1]) {
+                        cout << "Error in solve2Quads: if there are two solutions for e1, e2 "
+                                "should be degenerate!"
+                             << endl;
+                        E1.clear();
+                        E2.clear();
+                        return false;
+                    }
+
+                    E1.push_back(e1[0]);
+                    E1.push_back(e1[1]);
+                    ++i;
+                    continue;
+
+                } else {
+                    cout << "Error in solve2Quads: if there are two solutions for e1, e2 should be "
+                            "degenerate!"
+                         << endl;
+                    E1.clear();
+                    E2.clear();
+                    return false;
+                }
+            }
+
+        } else {
+            // There is no solution given this e2
+            E2.erase(E2.begin() + i);
+            --i;
+        }
+    }
+
+    return true;
+}
+
+bool solve2QuadsDeg(const double a11, const double a10, const double a01, const double a00,
+                    const double b11, const double b10, const double b01, const double b00,
+                    vector<double>& E1, vector<double>& E2, bool verbose) {
+
+    if (a11 == 0. && b11 == 0.)
+        return solve2Linear(a10, a01, a00, b10, b01, b00, E1, E2, verbose);
+
+    bool result = solveQuadratic(a11 * (b11 * a10 - a11 * b10),
+                                 a01 * (b11 * a10 - a11 * b10) - a01 * (b11 * a01 - a11 * b01) +
+                                         a11 * (b11 * a00 - a11 * b00),
+                                 a01 * (b11 * a00 - a11 * b00), E1, verbose);
+
+    if (!result) {
+        if (verbose) {
+            cout << "No solution to the system:" << endl;
+            cout << " " << a11 << "*E1*E2 + " << a10 << "*E1 + " << a01 << "*E2 + " << a00 << " = 0"
+                 << endl;
+            cout << " " << b11 << "*E1*E2 + " << b10 << "*E1 + " << b01 << "*E2 + " << b00 << " = 0"
+                 << endl;
+            cout << endl;
+        }
+        return false;
+    }
+
+    for (unsigned short i = 0; i < E1.size(); ++i) {
+
+        double denom = a11 * E1[i] + a01;
+
+        if (denom != 0) {
+            E2.push_back(-(a10 * E1[i] + a00) / denom);
+
+        } else {
+            denom = b11 * a01 - a11 * b01;
+            if (denom != 0.) {
+                E2.push_back(-((b11 * a10 - a11 * b10) * E1[i] + b11 * a00 - a11 * b00) / denom);
+            } else {
+                denom = b11 * E1[i] + b01;
+                if (denom != 0.) {
+                    E2.push_back(-(b10 * E1[i] + b00) / denom);
+                } else {
+                    E1.erase(E1.begin() + i);
+                    --i;
+                }
+            }
+        }
+    }
+
+    if (verbose) {
+        cout << "Solutions to the system:" << endl;
+        cout << " " << a11 << "*E1*E2 + " << a10 << "*E1 + " << a01 << "*E2 + " << a00 << " = 0"
+             << endl;
+        cout << " " << b11 << "*E1*E2 + " << b10 << "*E1 + " << b01 << "*E2 + " << b00 << " = 0"
+             << endl;
+        for (unsigned short i = 0; i < E1.size(); ++i)
+            cout << "  E1 = " << E1[i] << ", E2 = " << E2[i] << endl;
+        cout << endl;
+    }
+
+    return E1.size();
+}
+
+bool solve2Linear(const double a10, const double a01, const double a00, const double b10,
+                  const double b01, const double b00, std::vector<double>& E1,
+                  std::vector<double>& E2, bool verbose) {
+
+    const double det = a10 * b01 - b10 * a01;
+
+    if (det == 0.) {
+        if (a00 != 0. || b00 != 0.) {
+            if (verbose) {
+                cout << "No solution to the system:" << endl;
+                cout << " " << a10 << "*E1 + " << a01 << "*E2 + " << a00 << " = 0" << endl;
+                cout << " " << b10 << "*E1 + " << b01 << "*E2 + " << b00 << " = 0" << endl;
+                cout << endl;
+            }
+            return false;
+        } else {
+            cout << "Error in solve2Linear: indeterminate system:" << endl;
+            cout << " " << a10 << "*E1 + " << a01 << "*E2 + " << a00 << " = 0" << endl;
+            cout << " " << b10 << "*E1 + " << b01 << "*E2 + " << b00 << " = 0" << endl;
+            cout << endl;
+            return false;
+        }
+    }
+
+    const double e2 = (b10 * a00 - a10 * b00) / det;
+    E2.push_back(e2);
+    double e1;
+    if (a10 == 0.)
+        e1 = -(b00 + b01 * e2) / b10;
+    else
+        e1 = -(a00 + a01 * e2) / a10;
+    E1.push_back(e1);
+
+    if (verbose) {
+        cout << "Solution to the system:" << endl;
+        cout << " " << a10 << "*E1 + " << a01 << "*E2 + " << a00 << " = 0" << endl;
+        cout << " " << b10 << "*E1 + " << b01 << "*E2 + " << b00 << " = 0" << endl;
+        cout << "  E1 = " << e1 << ", E2 = " << e2 << endl << endl;
+    }
+
+    return true;
+}
+
+double BreitWigner(const double s, const double m, const double g) {
+    double k = m * g;
+    return k / (std::pow(s - m * m, 2.) + std::pow(m * g, 2.));
+}

--- a/core/src/MoMEMta.cc
+++ b/core/src/MoMEMta.cc
@@ -26,6 +26,7 @@
 #include <momemta/Logging.h>
 #include <momemta/ParameterSet.h>
 #include <momemta/Utils.h>
+#include <momemta/Unused.h>
 
 #include <Graph.h>
 

--- a/core/src/ParameterSet.cc
+++ b/core/src/ParameterSet.cc
@@ -19,7 +19,7 @@
 #include <momemta/ParameterSet.h>
 
 #include <momemta/Logging.h>
-#include <momemta/Utils.h>
+#include <momemta/Unused.h>
 
 #include <lua/utils.h>
 

--- a/examples/WW_fullyleptonic.cc
+++ b/examples/WW_fullyleptonic.cc
@@ -19,7 +19,7 @@
 
 #include <momemta/ConfigurationReader.h>
 #include <momemta/MoMEMta.h>
-#include <momemta/Utils.h>
+#include <momemta/Unused.h>
 
 #include <TH1D.h>
 

--- a/examples/tt_fullyleptonic.cc
+++ b/examples/tt_fullyleptonic.cc
@@ -20,7 +20,7 @@
 #include <momemta/ConfigurationReader.h>
 #include <momemta/Logging.h>
 #include <momemta/MoMEMta.h>
-#include <momemta/Utils.h>
+#include <momemta/Unused.h>
 
 #include <TH1D.h>
 

--- a/examples/tt_fullyleptonic_NWA.cc
+++ b/examples/tt_fullyleptonic_NWA.cc
@@ -20,7 +20,7 @@
 #include <momemta/ConfigurationReader.h>
 #include <momemta/Logging.h>
 #include <momemta/MoMEMta.h>
-#include <momemta/Utils.h>
+#include <momemta/Unused.h>
 
 #include <chrono>
 

--- a/include/momemta/Math.h
+++ b/include/momemta/Math.h
@@ -1,0 +1,222 @@
+/*
+ *  MoMEMta: a modular implementation of the Matrix Element Method
+ *  Copyright (C) 2016  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cmath>
+#include <vector>
+
+/// Compute \f$ x^2 \f$
+#define SQ(x) (x * x)
+/// Compute \f$ x^3 \f$
+#define CB(x) (x * x * x)
+/// Compute \f$ x^4 \f$
+#define QU(x) (x * x * x * x)
+
+/**
+ * \file
+ * \brief Mathematical functions
+ */
+
+/**
+ * \brief Sign function
+ *
+ * \return 1 if \p x is positive, -1 if \p x is negative, or 0 if x is null
+ */
+template <typename T> T sign(const T& x) {
+    if (x > 0)
+        return 1;
+    else if (!x)
+        return 0;
+    else
+        return -1;
+}
+
+/**
+ * \brief Compute \f$ \frac{dE}{dP} \f$
+ */
+template <typename T> inline double dE_over_dP(const T& v) {
+    const double rad = SQ(v.E()) - SQ(v.M());
+    if (rad <= 0)
+        return 0.;
+    else
+        return v.E() / std::sqrt(rad);
+}
+
+// If the NWA is used for a particle, a multiplication factor has to be introduced
+// because of the integrated-out delta function
+inline double jacobianNWA(const double mass, const double width) {
+    return (M_PI / 2. + std::atan(mass / width)) * mass * width;
+}
+
+// Compute cos(x +- 2*pi/3) in a more "analytical" way (pm = +- 1)
+// Useful for solveCubic
+inline double cosXpm2PI3(const double x, const double pm) {
+    return -0.5 * (std::cos(x) + pm * std::sin(x) * std::sqrt(3.));
+}
+
+/**
+ * \brief Finds the real solutions to \f$ a*x^2 + b*x + c = 0 \f$
+ *
+ * Uses a numerically more stable way than the "classroom" method.
+ * Handles special cases \f$ a = 0 \f$ and / or \f$ b = 0 \f$.
+ * Appends the solutions to \p roots, making no attempt to check whether the vector is empty.
+ * \note Double roots are present twice.
+ * See https://fr.wikipedia.org/wiki/Équation_du_second_degré#Calcul_numérique
+ *
+ * \param a, b, c Coefficient of quadratic equation
+ * \param[out] roots Roots of equation
+ * \param verbose If true, print the solution of the equation
+ *
+ * \return True if a solution has been found, false otherwise
+ */
+bool solveQuadratic(const double a, const double b, const double c, std::vector<double>& roots,
+                    bool verbose = false);
+
+/**
+ * \brief Finds the real solutions to \f$ a*x^3 + b*x^2 + c*x + d = 0 \f$
+ *
+ * Handles special cases \f$ a = 0 \f$.
+ *
+ * Appends the solutions to \p roots, making no attempt to check whether the vector is empty.
+ *
+ * \note Multiple roots are present multiple times.
+ *
+ * \note Inspired by "Numerical Recipes" (Press, Teukolsky, Vetterling, Flannery), 2007 Cambridge University Press
+ *
+ * \param a, b, c, d Coefficient of the equation
+ * \param[out] roots Roots of equation
+ * \param verbose If true, print the solution of the equation
+ *
+ * \return True if a solution has been found, false otherwise
+ */
+bool solveCubic(const double a, const double b, const double c, const double d,
+                std::vector<double>& roots, bool verbose = false);
+
+// Finds the real solutions to a*x^4 + b*x^3 + c*x^2 + d*x + e = 0
+// Handles special case a=0.
+// Appends the solutions to the std::vector roots, making no attempt to check whether the vector is
+// empty.
+// Multiple roots appear multiple times.
+// If verbose is true (default is false), the solutions are printed,
+// as well as the polynomial evaluated on these solutions
+//
+// See https://en.wikipedia.org/wiki/Quartic_function#Solving_by_factoring_into_quadratics
+//    https://fr.wikipedia.org/wiki/Méthode_de_Descartes
+//
+// .
+
+/**
+ * \brief Finds the real solutions to \f$ a*x^4 + b*x^3 + c*x^2 + d*x + e = 0 \f$
+ *
+ * Handles special cases \f$ a = 0 \f$.
+ *
+ * Appends the solutions to \p roots, making no attempt to check whether the vector is empty.
+ *
+ * The idea is to make a change of variable to eliminate the term in \f$ x^3 \f$, which gives a *depressed quartic*,
+ * then to try and factorize this quartic into two quadratic equations, which each then gives up to two roots.
+ * The factorization relies on solving a cubic equation (which is always possible), then taking the square root
+ * of one of these solution (ie there must be a positive solution)
+ *
+ * \note Multiple roots are present multiple times.
+ *
+ * \note See https://en.wikipedia.org/wiki/Quartic_function#Solving_by_factoring_into_quadratics and 
+ *       https://fr.wikipedia.org/wiki/Méthode_de_Descartes
+ *
+ * \param a, b, c, d, e Coefficient of the equation
+ * \param[out] roots Roots of equation
+ * \param verbose If true, print the solution of the equation
+ *
+ * \return True if a solution has been found, false otherwise
+ */
+bool solveQuartic(const double a, const double b, const double c, const double d, const double e,
+                  std::vector<double>& roots, bool verbose = false);
+
+/**
+ * \brief Solve a system of two quadratic equations
+ *
+ * Solves the system:
+ * \f[
+ * \begin{align*}
+ *   a_{20}E_1^2 + a_{02}E_2^2 + a_{11}E_1E_2 + a_{10}E_1 + a_{01}E_2 + a_{00} &= 0 \\
+ *   b_{20}E_1^2 + b_{02}E_2^2 + b_{11}E_1E_2 + b_{10}E_1 + b_{01}E_2 + b_{00} &= 0
+ *   \end{align*}
+ * \f]
+ * 
+ * Which corresponds to finding the intersection points of two conics.
+ * 
+ * Appends the (x,y) solutions to the std::vectors E1, E2, making no attempt to check
+ * whether these vectors are empty.
+ *
+ * In most cases it simply comes down to solving a quartic equation:
+ *   - eliminate the \f$ E_1^2 \f$ term
+ *   - solve for \f$ E_1 \f$ (linear!)
+ *   - inserting back gives a quartic function of \f$ E_2 \f$
+ *   - find solutions for \f$ E_1 \f$
+ *
+ * The procedure becomes tricky in some special cases (intersections aligned along x- or y-axis,
+ * degenerate conics, ...)
+ */
+bool solve2Quads(const double a20, const double a02, const double a11, const double a10,
+                 const double a01, const double a00, const double b20, const double b02,
+                 const double b11, const double b10, const double b01, const double b00,
+                 std::vector<double>& E1, std::vector<double>& E2, bool verbose = false);
+
+/**
+ * \brief Solve a system of two degenerated quadratic equations
+ *
+ * Solves the system:
+ * \f[
+ * \begin{align*}
+ *   a_{11}E_1E_2 + a_{10}E_1 + a_{01}E_2 + a_{00} &= 0 \\
+ *   b_{11}E_1E_2 + b_{10}E_1 + b_{01}E_2 + b_{00} &= 0
+ *   \end{align*}
+ * \f]
+ * 
+ * Which corresponds to finding the intersection points of two conics.
+ * 
+ * Appends the (x,y) solutions to the std::vectors E1, E2, making no attempt to check
+ * whether these vectors are empty.
+ *
+ */
+bool solve2QuadsDeg(const double a11, const double a10, const double a01, const double a00,
+                    const double b11, const double b10, const double b01, const double b00,
+                    std::vector<double>& E1, std::vector<double>& E2, bool verbose = false);
+
+/**
+ * \brief Solve a system of two linear equations
+ *
+ * Solves the system:
+ * \f[
+ * \begin{align*}
+ *   a_{10}E_1 + a_{01}E_2 + a_{00} &= 0 \\
+ *   b_{10}E_1 + b_{01}E_2 + b_{00} &= 0
+ *   \end{align*}
+ * \f]
+ * 
+ * Appends the (x,y) solutions to the std::vectors E1, E2, making no attempt to check
+ * whether these vectors are empty.
+ */
+bool solve2Linear(const double a10, const double a01, const double a00, const double b10,
+                  const double b01, const double b00, std::vector<double>& E1,
+                  std::vector<double>& E2, bool verbose = false);
+
+/**
+ * \brief A relativist Breit-Wigner distribution
+ */
+double BreitWigner(const double s, const double m, const double g);

--- a/include/momemta/Unused.h
+++ b/include/momemta/Unused.h
@@ -16,26 +16,9 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <momemta/Utils.h>
+#pragma once
 
-#ifdef __GNUG__
-#include <cstdlib>
-#include <cxxabi.h>
-#include <memory>
-
-std::string demangle(const char* name) {
-
-    int status = -4; // some arbitrary value to eliminate the compiler warning
-
-    std::unique_ptr<char, void (*)(void*)> res{abi::__cxa_demangle(name, NULL, NULL, &status),
-                                               std::free};
-
-    return (status == 0) ? res.get() : name;
-}
-
-#else
-
-// does nothing if not g++
-std::string demangle(const char* name) { return name; }
-
-#endif
+/**
+ * \brief Mark a variable as unused.
+ */
+template <typename T> void UNUSED(T &&) { }

--- a/include/momemta/Utils.h
+++ b/include/momemta/Utils.h
@@ -16,152 +16,20 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
-#ifndef _INC_UTILS
-#define _INC_UTILS
-
-#include <cmath>
-#include <vector>
 #include <algorithm>
 #include <string>
-
-#include <momemta/Types.h>
-
-#define SQ(x) (x*x)
-#define CB(x) (x*x*x)
-#define QU(x) (x*x*x*x)
-
-//#define M_PI 3.1415927410125732421875
-
-template<typename T> T sign(const T x){
-    if(x > 0)
-        return 1;
-    else if(!x)
-        return 0;
-    else
-        return -1;
-}
-
-// Used to compute Jacobian for Transfer Function
-inline double dE_over_dP(const LorentzVector& v){
-    const double rad = SQ(v.E()) - SQ(v.M());
-    if (rad <= 0)
-        return 0.;
-    else
-        return v.E() / std::sqrt(rad);
-}
-
-// If the NWA is used for a particle, a multiplication factor has to be introduced
-// because of the integrated-out delta function
-inline double jacobianNWA(const double mass, const double width){
-    return ( M_PI/2. + atan(mass / width) ) * mass * width;
-}
-
-// Compute cos(x +- 2*pi/3) in a more "analytical" way (pm = +- 1)
-// Useful for solveCubic
-inline double cosXpm2PI3(const double x, const double pm){
-    return -0.5*( cos(x) + pm * sin(x) * sqrt(3.) );
-}
-
-// Finds the real solutions to a*x^2 + b*x + c = 0
-// Uses a numerically more stable way than the "classroom" method.
-// Handles special cases a=0 and/or b=0.
-// Appends the solutions to the std::vector roots, making no attempt to check whether the vector is empty.
-// Double roots are present twice.
-// If verbose is true (default is false), the solutions are printed,
-// as well as the polynomial evaluated on these solutions
-//
-// See https://fr.wikipedia.org/wiki/Équation_du_second_degré#Calcul_numérique
-bool solveQuadratic(const double a, const double b, const double c,
-        std::vector<double>& roots,
-        bool verbose = false
-        );
-
-// Finds the real solutions to a*x^3 + b*x^2 + c*x + d = 0
-// Handles special case a=0.
-// Appends the solutions to the std::vector roots, making no attempt to check whether the vector is empty.
-// Multiple roots appear multiple times.
-// If verbose is true (default is false), the solutions are printed,
-// as well as the polynomial evaluated on these solutions
-//
-// Inspired by "Numerical Recipes" (Press, Teukolsky, Vetterling, Flannery), 2007 Cambridge University Press
-bool solveCubic(const double a, const double b, const double c, const double d,
-        std::vector<double>& roots,
-        bool verbose = false
-        );
-
-// Finds the real solutions to a*x^4 + b*x^3 + c*x^2 + d*x + e = 0
-// Handles special case a=0.
-// Appends the solutions to the std::vector roots, making no attempt to check whether the vector is empty.
-// Multiple roots appear multiple times.
-// If verbose is true (default is false), the solutions are printed,
-// as well as the polynomial evaluated on these solutions
-//
-// See https://en.wikipedia.org/wiki/Quartic_function#Solving_by_factoring_into_quadratics
-//    https://fr.wikipedia.org/wiki/Méthode_de_Descartes
-//
-// The idea is to make a change of variable to eliminate the term in x^3, which gives a "depressed quartic",
-// then to try and factorize this quartic into two quadratic equations, which each then gives up to two roots.
-// The factorization relies on solving a cubic equation (which is always possible),
-// then taking the square root of one of these solution (ie there must be a positive solution).
-bool solveQuartic(const double a, const double b, const double c, const double d, const double e,
-        std::vector<double>& roots,
-        bool verbose = false
-        );
-
-// Solves the system:
-// a20*E1^2 + a02*E2^2 + a11*E1*E2 + a10*E1 + a01*E2 + a00 = 0
-// b20*E1^2 + b02*E2^2 + b11*E1*E2 + b10*E1 + b01*E2 + b00 = 0
-// Which corresponds to finding the intersection points of two conics.
-// Appends the (x,y) solutions to the std::vectors E1, E2, making no attempt to check
-// whether these vectors are empty.
-// In most cases it simply comes down to solving a quartic equation:
-//   - eliminate the E1^2 term
-//   - solve for E1 (linear!)
-//   - inserting back gives a quartic function of E2
-//   - find solutions for E1
-// The procedure becomes tricky in some special cases
-// (intersections aligned along x- or y-axis, degenerate conics, ...)
-bool solve2Quads(const double a20, const double a02, const double a11, const double a10, const double a01, const double a00,
-        const double b20, const double b02, const double b11, const double b10, const double b01, const double b00,
-        std::vector<double>& E1, std::vector<double>& E2,
-        bool verbose = false
-        );
-
-// Solves the system:
-// a11*E1*E2 + a10*E1 + a01*E2 + a00 = 0
-// b11*E1*E2 + b10*E1 + b01*E2 + b00 = 0
-// Which corresponds to finding the intersection points of two conics.
-// Appends the (x,y) solutions to the std::vectors E1, E2, making no attempt to check
-// whether these vectors are empty.
-bool solve2QuadsDeg(const double a11, const double a10, const double a01, const double a00,
-        const double b11, const double b10, const double b01, const double b00,
-        std::vector<double>& E1, std::vector<double>& E2,
-        bool verbose = false
-        );
-
-// Solves the system:
-// a10*E1 + a01*E2 + a00 = 0
-// b10*E1 + b01*E2 + b00 = 0
-// Appends the (x,y) solutions to the std::vectors E1, E2, making no attempt to check
-// whether these vectors are empty.
-bool solve2Linear(const double a10, const double a01, const double a00,
-        const double b10, const double b01, const double b00,
-        std::vector<double>& E1, std::vector<double>& E2,
-        bool verbose = false);
-
-
-double BreitWigner(const double s, const double m, const double g);
+#include <vector>
 
 /*!
- * Convert a LorentzVector to a vector of real number.
+ * \brief Convert a LorentzVector to a vector of real number.
  *
- * @v   The LorentzVector to convert
+ * \param v The LorentzVector to convert
  *
- * @returns a vector of real number containing 4 entries: [E, Px, Py, Pz]
+ * \return a vector of real number containing 4 entries: [E, Px, Py, Pz]
  */
-template<class T>
-std::vector<typename T::Scalar> toVector(const T& v) {
+template <class T> std::vector<typename T::Scalar> toVector(const T& v) {
     return {v.E(), v.Px(), v.Py(), v.Pz()};
 }
 
@@ -180,8 +48,8 @@ std::vector<std::size_t> get_permutations(const std::vector<T>& from, const std:
     std::vector<std::size_t> p(from.size());
 
     std::transform(from.begin(), from.end(), p.begin(), [&from, &to](const T& item) -> std::size_t {
-                return std::distance(to.begin(), std::find(to.begin(), to.end(), item));
-            });
+        return std::distance(to.begin(), std::find(to.begin(), to.end(), item));
+    });
 
     return p;
 }
@@ -197,38 +65,37 @@ std::vector<std::size_t> get_permutations(const std::vector<T>& from, const std:
 template <typename T>
 void apply_permutations(std::vector<T>& vec, std::vector<std::size_t> const& p) {
     std::vector<T> sorted_vec(p.size());
-    std::transform(p.begin(), p.end(), sorted_vec.begin(), [&vec](int i) {
-                return vec[i];
-            });
+    std::transform(p.begin(), p.end(), sorted_vec.begin(), [&vec](int i) { return vec[i]; });
 
     vec = sorted_vec;
 }
 
 std::string demangle(const char* name);
 
-template <typename T> void UNUSED(T &&) { }
-
 namespace cuba {
 
-inline unsigned int createFlagsBitset(char verbosity, bool subregion, bool retainStateFile, unsigned int level, bool smoothing, bool takeOnlyGridFromFile) {
+inline unsigned int createFlagsBitset(char verbosity, bool subregion, bool retainStateFile,
+                                      unsigned int level, bool smoothing,
+                                      bool takeOnlyGridFromFile) {
 
     unsigned int flags = 0;
 
-    static unsigned int opt_subregion = 0x04; // bit 2 (=4)
-    static unsigned int opt_smoothing = 0x08; // bit 3 (=8)
-    static unsigned int opt_retainStateFile = 0x10; // bit 4 (=16)
+    static unsigned int opt_subregion = 0x04;            // bit 2 (=4)
+    static unsigned int opt_smoothing = 0x08;            // bit 3 (=8)
+    static unsigned int opt_retainStateFile = 0x10;      // bit 4 (=16)
     static unsigned int opt_takeOnlyGridFromFile = 0x20; // bit 5 (=32)
 
-    level <<= 8; // bits 8-31
+    level <<= 8;                // bits 8-31
     flags |= level | verbosity; // verbosity: bits 0-1
-    if(subregion) flags |= opt_subregion;
-    if(!smoothing) flags |= opt_smoothing; // careful true-false inverted
-    if(retainStateFile) flags |= opt_retainStateFile;
-    if(takeOnlyGridFromFile) flags |= opt_takeOnlyGridFromFile;
+    if (subregion)
+        flags |= opt_subregion;
+    if (!smoothing)
+        flags |= opt_smoothing; // careful true-false inverted
+    if (retainStateFile)
+        flags |= opt_retainStateFile;
+    if (takeOnlyGridFromFile)
+        flags |= opt_takeOnlyGridFromFile;
 
     return flags;
 }
-
 }
-
-#endif

--- a/modules/BinnedTransferFunctionOnEnergy.cc
+++ b/modules/BinnedTransferFunctionOnEnergy.cc
@@ -20,7 +20,7 @@
 #include <momemta/Module.h>
 #include <momemta/ParameterSet.h>
 #include <momemta/Types.h>
-#include <momemta/Utils.h>
+#include <momemta/Math.h>
 
 
 #include <TFile.h>

--- a/modules/BlockB.cc
+++ b/modules/BlockB.cc
@@ -20,7 +20,7 @@
 #include <momemta/ParameterSet.h>
 #include <momemta/Module.h>
 #include <momemta/Types.h>
-#include <momemta/Utils.h>
+#include <momemta/Math.h>
 
 
 /** \brief \f$\require{cancel}\f$ Final (main) Block B, describing \f$q_1 q_2 \to X + s_{12} (\to \cancel{p_1} p_2)\f$

--- a/modules/BlockD.cc
+++ b/modules/BlockD.cc
@@ -20,7 +20,7 @@
 #include <momemta/ParameterSet.h>
 #include <momemta/Module.h>
 #include <momemta/Types.h>
-#include <momemta/Utils.h>
+#include <momemta/Math.h>
 
 /** \brief \f$\require{cancel}\f$ Final (main) Block D, describing \f$X + s_{134} (\to p_4 + s_{13} (\to \cancel{p_1} p_3)) + s_{256} (\to p_6 + s_{25} (\to \cancel{p_2} p_5))\f$
  *

--- a/modules/BlockF.cc
+++ b/modules/BlockF.cc
@@ -20,7 +20,7 @@
 #include <momemta/Module.h>
 #include <momemta/ParameterSet.h>
 #include <momemta/Types.h>
-#include <momemta/Utils.h>
+#include <momemta/Math.h>
 
 #include <TMath.h>
 

--- a/modules/FlatTransferFunctionOnP.cc
+++ b/modules/FlatTransferFunctionOnP.cc
@@ -19,7 +19,7 @@
 #include <momemta/ParameterSet.h>
 #include <momemta/Module.h>
 #include <momemta/Types.h>
-#include <momemta/Utils.h>
+#include <momemta/Math.h>
 
 /** \brief Flat transfer function on |P| (mainly for testing purposes). 
  *

--- a/modules/GaussianTransferFunction.cc
+++ b/modules/GaussianTransferFunction.cc
@@ -21,7 +21,7 @@
 #include <momemta/Module.h>
 #include <momemta/ParameterSet.h>
 #include <momemta/Types.h>
-#include <momemta/Utils.h>
+#include <momemta/Math.h>
 
 #include <Math/DistFunc.h>
 

--- a/modules/MatrixElement.cc
+++ b/modules/MatrixElement.cc
@@ -24,6 +24,7 @@
 #include <momemta/MatrixElement.h>
 #include <momemta/MatrixElementFactory.h>
 #include <momemta/ParameterSet.h>
+#include <momemta/Math.h>
 #include <momemta/Module.h>
 #include <momemta/Types.h>
 #include <momemta/Utils.h>

--- a/tests/crossSections/blockD_ttx_dilep.cc
+++ b/tests/crossSections/blockD_ttx_dilep.cc
@@ -19,7 +19,8 @@
 
 #include <momemta/ConfigurationReader.h>
 #include <momemta/MoMEMta.h>
-#include <momemta/Utils.h>
+#include <momemta/Types.h>
+#include <momemta/Unused.h>
 
 #include <chrono>
 

--- a/tests/crossSections/blockF_WW_dilep.cc
+++ b/tests/crossSections/blockF_WW_dilep.cc
@@ -19,7 +19,8 @@
 
 #include <momemta/ConfigurationReader.h>
 #include <momemta/MoMEMta.h>
-#include <momemta/Utils.h>
+#include <momemta/Types.h>
+#include <momemta/Unused.h>
 
 #include <chrono>
 

--- a/tests/phaseSpaceVolume/blockD.cc
+++ b/tests/phaseSpaceVolume/blockD.cc
@@ -19,7 +19,8 @@
 
 #include <momemta/ConfigurationReader.h>
 #include <momemta/MoMEMta.h>
-#include <momemta/Utils.h>
+#include <momemta/Types.h>
+#include <momemta/Unused.h>
 
 #include <chrono>
 

--- a/tests/phaseSpaceVolume/blockF.cc
+++ b/tests/phaseSpaceVolume/blockF.cc
@@ -19,7 +19,8 @@
 
 #include <momemta/ConfigurationReader.h>
 #include <momemta/MoMEMta.h>
-#include <momemta/Utils.h>
+#include <momemta/Types.h>
+#include <momemta/Unused.h>
 
 #include <chrono>
 


### PR DESCRIPTION
Move things from `Utils.h` to `Unused.h` and `Math.h`

 - `Math.h` contains all the maths functions
 - `Unused.h` contains the `UNUSED` declaration
 - `Utils.h` keeps functions I have no clue where to put otherwise :)

I also used `clang-formatter` to reformat the source code of math functions.