### PR TITLE
Switched to double in BreitWignerGenerator

### DIFF
--- a/modules/BreitWignerGenerator.cc
+++ b/modules/BreitWignerGenerator.cc
@@ -93,8 +93,8 @@ class BreitWignerGenerator: public Module {
         }
 
     private:
-        const float mass;
-        const float width;
+        const double mass;
+        const double width;
 
         // Inputs
         Value<double> m_ps_point;


### PR DESCRIPTION
Fixes #75 . A small difference in the final result is expected due to the propagation of rounding errors and the iterative nature of Vegas.

This will have to be backported to v0.1.