### PR TITLE
Allow vector integrands

### DIFF
--- a/core/src/Configuration.cc
+++ b/core/src/Configuration.cc
@@ -49,7 +49,7 @@ Configuration::Configuration(const Configuration& other) {
         global_parameters.reset(other.global_parameters->clone());
     if (other.cuba_configuration)
         cuba_configuration.reset(other.cuba_configuration->clone());
-    integrand = other.integrand;
+    integrands = other.integrands;
     paths = other.paths;
 }
 
@@ -57,7 +57,7 @@ Configuration::Configuration(const Configuration&& other) {
     modules = std::move(other.modules);
     global_parameters = std::move(other.global_parameters);
     cuba_configuration = std::move(other.cuba_configuration);
-    integrand = std::move(other.integrand);
+    integrands = std::move(other.integrands);
     paths = std::move(other.paths);
 }
 
@@ -78,8 +78,8 @@ const ParameterSet& Configuration::getGlobalParameters() const {
     return *global_parameters;
 }
 
-InputTag Configuration::getIntegrand() const {
-    return integrand;
+std::vector<InputTag> Configuration::getIntegrands() const {
+    return integrands;
 }
 
 std::vector<PathElementsPtr> Configuration::getPaths() const {

--- a/core/src/ConfigurationReader.cc
+++ b/core/src/ConfigurationReader.cc
@@ -83,7 +83,7 @@ void ConfigurationReader::onModuleDeclared(const std::string& type, const std::s
 }
 
 void ConfigurationReader::onIntegrandDeclared(const InputTag& tag) {
-    configuration.integrand = tag;
+    configuration.integrands.push_back(tag);
 }
 
 void ConfigurationReader::onNewPath(PathElementsPtr path) {

--- a/core/src/MoMEMta.cc
+++ b/core/src/MoMEMta.cc
@@ -66,14 +66,20 @@ MoMEMta::MoMEMta(const Configuration& configuration) {
 
     // Integrand
     // First, check if the user defined which integrand to use
-    InputTag integrand = configuration.getIntegrand();
-    if (integrand.empty()) {
+    std::vector<InputTag> integrands = configuration.getIntegrands();
+    if (!integrands.size()) {
         LOG(fatal) << "No integrand found. Define which module's output you want to use as the integrand using the lua `integrand` function.";
         throw integrands_output_error("No integrand found");
     }
 
+    // Next, retrieve all the input tags for the components of the integrand
     m_pool->current_module("momemta");
-    m_integrand = m_pool->get<double>(integrand);
+
+    for(const auto& component: integrands) {
+        m_integrands.push_back(m_pool->get<double>(component));
+        LOG(debug) << "Configuration declared integrand component using: " << component.toString();
+    }
+    m_n_components = m_integrands.size();
 
     m_cuba_configuration = configuration.getCubaConfiguration();
 
@@ -137,11 +143,19 @@ std::vector<std::pair<double, double>> MoMEMta::computeWeights(const std::vector
     // Output from cuba
     long long int neval = 0;
     int nfail = 0;
-    double mcResult = 0, prob = 0, error = 0;
-
+    std::unique_ptr<double[]> mcResult(new double[m_n_components]); 
+    std::unique_ptr<double[]> prob(new double[m_n_components]); 
+    std::unique_ptr<double[]> error(new double[m_n_components]); 
+    
+    for (size_t i = 0; i < m_n_components; i++) {
+        mcResult[i] = 0;
+        prob[i] = 0;
+        error[i] = 0;
+    }
+    
     llVegas(
          m_n_dimensions,         // (int) dimensions of the integrated volume
-         1,                      // (int) dimensions of the integrand
+         m_n_components,         // (int) dimensions of the integrand
          (integrand_t) CUBAIntegrand,  // (integrand_t) integrand (cast to integrand_t)
          (void*) this,           // (void*) pointer to additional arguments passed to integrand
          1,                      // (int) maximum number of points given the integrand in each invocation (=> SIMD) ==> PS points = vector of sets of points (x[ndim][nvec]), integrand returns vector of vector values (f[ncomp][nvec])
@@ -159,9 +173,9 @@ std::vector<std::pair<double, double>> MoMEMta::computeWeights(const std::vector
          NULL,                   // (int*) "spinning cores": -1 || NULL <=> integrator takes care of starting & stopping child processes (other value => keep or retrieve child processes, probably not useful here)
          &neval,                 // (int*) actual number of evaluations done
          &nfail,                 // 0=desired accuracy was reached; -1=dimensions out of range; >0=accuracy was not reached
-         &mcResult,              // (double*) integration result ([ncomp])
-         &error,                 // (double*) integration error ([ncomp])
-         &prob                   // (double*) Chi-square p-value that error is not reliable (ie should be <0.95) ([ncomp])
+         mcResult.get(),         // (double*) integration result ([ncomp])
+         error.get(),            // (double*) integration error ([ncomp])
+         prob.get()              // (double*) Chi-square p-value that error is not reliable (ie should be <0.95) ([ncomp])
     );
     
     if (nfail == 0) {
@@ -178,7 +192,12 @@ std::vector<std::pair<double, double>> MoMEMta::computeWeights(const std::vector
         module->endIntegration();
     }
 
-    return std::vector<std::pair<double, double>>({{mcResult, error}});
+    std::vector<std::pair<double, double>> result;
+    for (size_t i = 0; i < m_n_components; i++) {
+        result.push_back( std::make_pair(mcResult[i], error[i]) );
+    }
+
+    return result;
 }
 
 #define CUBA_ABORT -999
@@ -198,16 +217,19 @@ int MoMEMta::integrand(const double* psPoints, const double* weights, double* re
         if (status == Module::Status::NEXT) {
             // Stop executation for the current integration step
             // Returns 0 so that cuba knows this phase-space volume is not relevant
-            *results = 0;
+            for (size_t i = 0; i < m_n_components; i++)
+                results[i] = 0;
             return CUBA_OK;
         } else if (status == Module::Status::ABORT) {
             // Abort integration
-            *results = 0;
+            for (size_t i = 0; i < m_n_components; i++)
+                results[i] = 0;
             return CUBA_ABORT;
         }
     }
 
-    *results = *m_integrand;
+    for (size_t i = 0; i < m_n_components; i++)
+        results[i] = *(m_integrands[i]);
 
     return CUBA_OK;
 }

--- a/core/src/lua/utils.cc
+++ b/core/src/lua/utils.cc
@@ -487,18 +487,20 @@ namespace lua {
 
     int set_final_module(lua_State* L) {
         int n = lua_gettop(L);
-        if (n != 1) {
-            luaL_error(L, "invalid number of arguments: 1 expected, got %d", n);
-        }
-
-        std::string input_tag = luaL_checkstring(L, 1);
-        if (!InputTag::isInputTag(input_tag)) {
-            luaL_error(L, "'%s' is not a valid InputTag", input_tag.c_str());
+        if (n == 0) {
+            luaL_error(L, "invalid number of arguments: at least one expected, got 0");
         }
 
         void* cfg_ptr = lua_touserdata(L, lua_upvalueindex(1));
         ILuaCallback* callback = static_cast<ILuaCallback*>(cfg_ptr);
-        callback->onIntegrandDeclared(InputTag::fromString(input_tag));
+        
+        for(size_t i = 1; i <= size_t(n); i++) {
+            std::string input_tag = luaL_checkstring(L, i);
+            if (!InputTag::isInputTag(input_tag)) {
+                luaL_error(L, "'%s' is not a valid InputTag", input_tag.c_str());
+            }
+            callback->onIntegrandDeclared(InputTag::fromString(input_tag));
+        }
 
         return 0;
     }

--- a/examples/tt_fullyleptonic.lua
+++ b/examples/tt_fullyleptonic.lua
@@ -54,9 +54,9 @@ parameters = {
 
 cuba = {
     relative_accuracy = 0.01,
-    verbosity = 3
+    verbosity = 3,
 }
-
+ 
 BreitWignerGenerator.flatter_s13 = {
     -- getpspoint() generates an input tag of type `cuba::ps_points/i`
     -- where `i` is automatically incremented each time the function is called.
@@ -239,5 +239,4 @@ Looper.looper = {
     }
 
 -- End of loop
-
 integrand("integrand::sum")

--- a/include/momemta/Configuration.h
+++ b/include/momemta/Configuration.h
@@ -59,7 +59,7 @@ class Configuration {
         /// \return The global parameters as declared in the configuration file
         const ParameterSet& getGlobalParameters() const;
         /// \return The integrand InputTag as declared in the configuration
-        InputTag getIntegrand() const;
+        std::vector<InputTag> getIntegrands() const;
         /// \return The list of Paths as declared in the configuration
         std::vector<PathElements*> getPaths() const;
 
@@ -87,6 +87,6 @@ class Configuration {
         std::vector<Module> modules;
         std::shared_ptr<ParameterSet> global_parameters;
         std::shared_ptr<ParameterSet> cuba_configuration;
-        InputTag integrand;
+        std::vector<InputTag> integrands;
         std::vector<PathElements*> paths;
 };

--- a/include/momemta/MoMEMta.h
+++ b/include/momemta/MoMEMta.h
@@ -100,6 +100,7 @@ class MoMEMta {
         std::vector<SharedLibraryPtr> m_libraries;
 
         size_t m_n_dimensions;
+        size_t m_n_components;
         ParameterSet m_cuba_configuration;
 
         IntegrationStatus integration_status = IntegrationStatus::NONE;
@@ -109,5 +110,5 @@ class MoMEMta {
         std::shared_ptr<double> m_ps_weight;
         std::shared_ptr<std::vector<LorentzVector>> m_particles;
         std::shared_ptr<LorentzVector> m_met;
-        Value<double> m_integrand;
+        std::vector<Value<double>> m_integrands;
 };

--- a/tests/unit_tests/lua.cc
+++ b/tests/unit_tests/lua.cc
@@ -53,7 +53,7 @@ class LuaCallbackMock: public ILuaCallback {
         }
 
         virtual void onIntegrandDeclared(const InputTag& tag) {
-            integrand = tag;
+            integrands.push_back(tag);
         }
 
         virtual void onNewPath(PathElementsPtr path) {
@@ -61,7 +61,7 @@ class LuaCallbackMock: public ILuaCallback {
         }
 
         std::vector<std::pair<std::string, std::string>> modules;
-        InputTag integrand;
+        std::vector<InputTag> integrands;
         std::vector<PathElementsPtr> paths;
 };
 
@@ -101,6 +101,10 @@ TEST_CASE("lua parsing utilities", "[lua]") {
         value = lua::to_any(L.get(), -1);
         REQUIRE( (boost::any_cast<InputTag>(value.first)).toString() == "cuba::ps_points/2");
         lua_pop(L.get(), 2);
+
+        execute_string(L, "integrand('integrand1::output', 'integrand2::output')");
+        REQUIRE( luaCallback.integrands.size() == 2 );
+        REQUIRE( luaCallback.integrands.at(1).toString() == "integrand2::output" );
     }
 
     SECTION("defining modules") {


### PR DESCRIPTION
Take advantage of Cuba's feature allowing vector integrands: each component is integrated in parallel, the grid being optimised for all of them (obviously, this only works if all components are similar).

Does not change much for the user: `MoMEMta::computeWeights()` is not modified. To define the components, simply give several input tags as arguments to the `integrand()` function in Lua:
```
integrand("integrand1::sum", "integrand2::sum")
```
integrates the output of modules `integrand1` and `integrand2` separately.