### PR TITLE
Python bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
   - cd build
   - cmake .. -DTESTS=ON -DCOVERAGE=ON -DPYTHON_BINDINGS=ON -DCMAKE_BUILD_TYPE=Debug
 script:
-  - make -j2 && ./tests/unit_tests/unit_tests.exe
+  - make -j2 && ./run_tests.sh
 after_success:
   - coveralls -e 'external/' --gcov-options '\-lp' -E '.*CMakeCXXCompilerId\.cpp' -E '.*CMakeCCompilerId\.c' -E '.*feature_tests\.c.*' -E '.*MatrixElements/.*' -E '.*/tests/*.' -r .. &> /dev/null;
   - if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then ./make_docs.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ addons:
       - g++-4.9
       - libboost1.55-dev
       - libboost-log1.55-dev
+      - libboost-python1.55-dev
+      - libboost-regex1.55-dev
       - graphviz
 before_install:
   - ./travis/decrypt_key.sh 
@@ -29,13 +31,13 @@ install:
   - source travis/get-cmake.sh
   - source travis/get-root.sh
   - source travis/get-lhapdf.sh
-  - source travis/get-doxygen.sh
+  - if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then source travis/get-doxygen.sh; fi
 before_script:
   - export CXX=g++-4.9
   - export CC=gcc-4.9
   - mkdir build
   - cd build
-  - cmake .. -DTESTS=ON -DCOVERAGE=ON -DCMAKE_BUILD_TYPE=Debug
+  - cmake .. -DTESTS=ON -DCOVERAGE=ON -DPYTHON_BINDINGS=ON -DCMAKE_BUILD_TYPE=Debug
 script:
   - make -j2 && ./tests/unit_tests/unit_tests.exe
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,14 @@ language: cpp
 compiler:
   - gcc
 env:
-  - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.2.1
-  - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.5.2
-  - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.6.1
-  - ROOT_VERSION=5.34.25 CMAKE_VERSION=3.6.1
+  global:
+    - PYTHON=true
+  matrix:
+    - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.2.1
+    - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.5.2
+    - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.6.1
+    - ROOT_VERSION=5.34.25 CMAKE_VERSION=3.6.1
+    - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.6.1 PYTHON=false
 addons:
   apt:
     sources:
@@ -19,12 +23,12 @@ addons:
       - g++-4.9
       - libboost1.55-dev
       - libboost-log1.55-dev
-      - libboost-python1.55-dev
       - libboost-regex1.55-dev
       - graphviz
 before_install:
   - ./travis/decrypt_key.sh 
   - pip install --user cpp-coveralls
+  - if [[ $PYTHON == 'true' ]]; then sudo apt-get -y install libboost-python1.55-dev; fi
 install:
   - export CXX=g++-4.9
   - export CC=gcc-4.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
  - New `Looper` module to loop over a set of solutions (see below for more details)
  - Secondary block C/D
+ - Python bindings. To enable, pass `-DPYTHON_BINDINGS=ON` to `cmake`.
 
 ### Changed
  - The way to handle multiple solutions coming from blocks has changed. A module is no longer responsible for looping over the solutions itself, this role is delegate to the `Looper` module. As a consequence, most of the module were rewritten to handle this change. See this [Pull Request](https://github.com/MoMEMta/MoMEMta/pull/69) for a more technical description, and this [documentation entry](http://momemta.github.io/) for more details

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ endif()
 
 option(COVERAGE "Enable code coverage" OFF)
 
+option(PYTHON_BINDINGS "Build python bindings. Python needs to be available" OFF)
+
 # Set a default build type for single-configuration
 # CMake generators if no build type is set.
 if (NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
@@ -68,8 +70,59 @@ endif()
 
 set(Boost_NO_BOOST_CMAKE ON)
 find_package(Boost 1.54 REQUIRED log)
+
+if (NOT TARGET Boost::log)
+    add_library(Boost::log INTERFACE IMPORTED)
+    set_property(TARGET Boost::log PROPERTY INTERFACE_LINK_LIBRARIES ${Boost_LOG_LIBRARY})
+    set_property(TARGET Boost::log PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS})
+    set_property(TARGET Boost::log PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS})
+endif()
+
 # Needed since we don't link to the static library
-add_definitions(-DBOOST_LOG_DYN_LINK)
+set_property(TARGET Boost::log PROPERTY INTERFACE_COMPILE_DEFINITIONS "BOOST_LOG_DYN_LINK")
+
+if (PYTHON_BINDINGS)
+    find_package(PythonLibs 2.6)
+    if (PYTHONLIBS_FOUND)
+
+        if (NOT TARGET Python::libs)
+            add_library(Python::libs INTERFACE IMPORTED)
+            set_property(TARGET Python::libs PROPERTY INTERFACE_LINK_LIBRARIES ${PYTHON_LIBRARIES})
+            set_property(TARGET Python::libs PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PYTHON_INCLUDE_PATH})
+            set_property(TARGET Python::libs PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${PYTHON_INCLUDE_PATH})
+        endif()
+
+        find_package(PythonInterp 2.6)
+
+        find_package(Boost 1.54 COMPONENTS python)
+        if (NOT Boost_PYTHON_FOUND)
+            message(WARNING "Boost python not found. Not building python bindings")
+            set(PYTHON_BINDINGS OFF)
+        elseif(NOT TARGET Boost::python)
+            add_library(Boost::python INTERFACE IMPORTED)
+            set_property(TARGET Boost::python PROPERTY INTERFACE_LINK_LIBRARIES ${Boost_PYTHON_LIBRARY})
+            set_property(TARGET Boost::python PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS})
+            set_property(TARGET Boost::python PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS})
+        endif()
+
+    else()
+        message(WARNING "Python not found. Not building python bindings")
+        set(PYTHON_BINDINGS OFF)
+    endif()
+
+endif()
+
+if (PYTHON_BINDINGS)
+    message(STATUS "Building python bindings")
+
+    # Look for pyroot, optional
+    find_library(ROOT_PYROOT_LIBRARY PyROOT HINTS ${ROOT_LIBRARY_DIR})
+    add_library(Root::python INTERFACE IMPORTED)
+    if (ROOT_PYROOT_LIBRARY)
+        set_property(TARGET Root::python APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS "ROOT_HAS_PYROOT")
+        set_property(TARGET Root::python APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${ROOT_PYROOT_LIBRARY})
+    endif()
+endif()
 
 # Include external
 add_subdirectory(external)
@@ -141,7 +194,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Public interface
 target_include_directories(momemta PUBLIC "${CMAKE_CURRENT_LIST_DIR}/include")
-target_include_directories(momemta SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 
 # Private interface
 target_include_directories(momemta PRIVATE "${CMAKE_CURRENT_LIST_DIR}/core/include")
@@ -153,7 +205,7 @@ target_link_libraries(momemta PRIVATE LHAPDF::LHAPDF)
 
 target_link_libraries(momemta PUBLIC dl)
 target_link_libraries(momemta PUBLIC Root::Root)
-target_link_libraries(momemta PUBLIC ${Boost_LIBRARIES})
+target_link_libraries(momemta PUBLIC Boost::log)
 target_link_libraries(momemta PUBLIC Threads::Threads)
 
 find_library(ROOT_GENVECTOR_LIBRARY GenVector HINTS ${ROOT_LIBRARY_DIR})
@@ -170,6 +222,20 @@ target_link_libraries(momemta PRIVATE matrix_elements)
 
 add_library(empty_module SHARED "modules/EmptyModule.cc")
 target_link_libraries(empty_module momemta)
+
+# Bindings
+
+if (PYTHON_BINDINGS)
+    set(BINDING_SOURCES
+            core/src/python/bindings.cc
+    )
+
+    add_library(momemta_python SHARED ${BINDING_SOURCES})
+
+    target_link_libraries(momemta_python PRIVATE Python::libs Boost::python Root::python momemta)
+    set_target_properties(momemta_python PROPERTIES PREFIX "")
+    set_target_properties(momemta_python PROPERTIES OUTPUT_NAME "momemta")
+endif()
 
 # Example executables
 
@@ -209,6 +275,14 @@ install(TARGETS momemta
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib)
+
+if(PYTHON_BINDINGS)
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_lib(prefix='', plat_specific=True))"
+            OUTPUT_VARIABLE PYTHON_INSTALL_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    install(TARGETS momemta_python
+            LIBRARY DESTINATION ${PYTHON_INSTALL_PREFIX})
+endif()
 
 # Uninstall target
 configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,11 @@ endif()
 option(TESTS "Compile tests" OFF)
 
 if(TESTS)
+    configure_file(
+            "${CMAKE_CURRENT_SOURCE_DIR}/cmake/scripts/run_tests.sh.in"
+            "${CMAKE_CURRENT_BINARY_DIR}/run_tests.sh"
+            IMMEDIATE @ONLY)
+
     add_subdirectory(tests)
 endif()
 

--- a/cmake/scripts/run_tests.sh.in
+++ b/cmake/scripts/run_tests.sh.in
@@ -8,6 +8,8 @@ set -e
 # C++ unit tests
 ./tests/unit_tests/unit_tests.exe
 
-# Python integration tests
-export PYTHONPATH="@CMAKE_BINARY_DIR@:$PYTHONPATH"
-python "@CMAKE_SOURCE_DIR@/tests/bindings/python/integration_tests.py" "@CMAKE_SOURCE_DIR@/tests/bindings/python/configuration.lua"
+if [[ "@PYTHON_BINDINGS@" == "ON" ]]; then
+    # Python integration tests
+    export PYTHONPATH="@CMAKE_BINARY_DIR@:$PYTHONPATH"
+    python "@CMAKE_SOURCE_DIR@/tests/bindings/python/integration_tests.py" "@CMAKE_SOURCE_DIR@/tests/bindings/python/configuration.lua"
+fi

--- a/cmake/scripts/run_tests.sh.in
+++ b/cmake/scripts/run_tests.sh.in
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+echo "Running tests for MoMEMta"
+
+# Exit on error
+set -e
+
+# C++ unit tests
+./tests/unit_tests/unit_tests.exe
+
+# Python integration tests
+export PYTHONPATH="@CMAKE_BINARY_DIR@:$PYTHONPATH"
+python "@CMAKE_SOURCE_DIR@/tests/bindings/python/integration_tests.py" "@CMAKE_SOURCE_DIR@/tests/bindings/python/configuration.lua"

--- a/core/src/python/bindings.cc
+++ b/core/src/python/bindings.cc
@@ -27,6 +27,12 @@
 #include <TPython.h>
 #endif
 
+/**
+ * \file
+ * \brief Python bindings
+ * \defgroup Python Python bindings
+ */
+
 namespace bp = boost::python;
 
 void set_log_level(boost::log::trivial::severity_level severity) {

--- a/core/src/python/bindings.cc
+++ b/core/src/python/bindings.cc
@@ -1,0 +1,202 @@
+/*
+ *  MoMEMta: a modular implementation of the Matrix Element Method
+ *  Copyright (C) 2016  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <momemta/Configuration.h>
+#include <momemta/ConfigurationReader.h>
+#include <momemta/MoMEMta.h>
+#include <momemta/Logging.h>
+
+#include <boost/python.hpp>
+
+#ifdef ROOT_HAS_PYROOT
+#include <TPython.h>
+#endif
+
+namespace bp = boost::python;
+
+void set_log_level(boost::log::trivial::severity_level severity) {
+    logging::set_level(severity);
+}
+
+bp::list MoMEMta_computeWeights_MET(MoMEMta& m, bp::list particles_, bp::list met_) {
+    std::vector<LorentzVector> particles;
+    for (ssize_t i = 0; i < bp::len(particles_); i++) {
+        particles.push_back(bp::extract<LorentzVector>(particles_[i]));
+    }
+
+    LorentzVector met;
+    bp::extract<LorentzVector> lorentzVectorExtractor(met_);
+    if (lorentzVectorExtractor.check())
+        met = lorentzVectorExtractor();
+
+    auto weights = m.computeWeights(particles, met);
+
+    bp::list result;
+    for (const auto& weight: weights) {
+        bp::tuple pair = bp::make_tuple(weight.first, weight.second);
+        result.append(pair);
+    }
+
+    return result;
+}
+
+bp::list MoMEMta_computeWeights(MoMEMta& m, bp::list particles) {
+    return MoMEMta_computeWeights_MET(m, particles, bp::list());
+}
+
+template<typename T>
+const T& ParameterSet_get(ParameterSet& p, const std::string& name) {
+    return p.get<T>(name);
+}
+
+template<typename T>
+void ParameterSet_set(ParameterSet& p, const std::string& name, const T& value) {
+    return p.set<T>(name, value);
+}
+
+struct LorentzVector_to_python {
+    static PyObject* convert(LorentzVector const& s) {
+        bp::list result;
+        result.append(s.X());
+        result.append(s.Y());
+        result.append(s.Z());
+        result.append(s.T());
+
+        return boost::python::incref(result.ptr());
+    }
+};
+
+struct LorentzVector_from_python {
+    LorentzVector_from_python() {
+        bp::converter::registry::push_back(
+                &convertible,
+                &construct,
+                boost::python::type_id<LorentzVector>());
+    }
+
+    static void* convertible(PyObject* obj_ptr) {
+        if (! PyList_Check(obj_ptr))
+            return nullptr;
+
+        if (PyList_Size(obj_ptr) != 4)
+            return nullptr;
+
+        return obj_ptr;
+    }
+
+    static void construct(
+            PyObject* obj_ptr,
+            bp::converter::rvalue_from_python_stage1_data* data) {
+        //if (value == 0) boost::python::throw_error_already_set();
+
+        void* storage = (
+                (bp::converter::rvalue_from_python_storage<LorentzVector>*)
+                        data)->storage.bytes;
+        new (storage) LorentzVector(
+                bp::extract<double>(PyList_GET_ITEM(obj_ptr, 0)),
+                bp::extract<double>(PyList_GET_ITEM(obj_ptr, 1)),
+                bp::extract<double>(PyList_GET_ITEM(obj_ptr, 2)),
+                bp::extract<double>(PyList_GET_ITEM(obj_ptr, 3))
+        );
+        data->convertible = storage;
+    }
+};
+
+#ifdef ROOT_HAS_PYROOT
+template <typename T>
+struct convert_py_root_to_cpp_root {
+    convert_py_root_to_cpp_root() {
+        bp::converter::registry::push_back(&convertible, &construct,
+                                           bp::type_id<T>());
+    }
+    static void* convertible(PyObject* obj_ptr) {
+        return TPython::ObjectProxy_Check(obj_ptr) ? obj_ptr : nullptr;
+    }
+
+    static void construct(PyObject* obj_ptr,
+                          bp::converter::rvalue_from_python_stage1_data* data) {
+        T* TObj = static_cast<T*>(TPython::ObjectProxy_AsVoidPtr(obj_ptr));
+        data->convertible = TObj;
+    }
+};
+#endif
+
+// Overloads for MoMEMta::computeWeights
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(MoMEMta_computeWeights_overloads, MoMEMta::computeWeights, 1, 2)
+
+BOOST_PYTHON_MODULE(momemta) {
+
+    using namespace boost::python;
+
+    to_python_converter<LorentzVector, LorentzVector_to_python>();
+    LorentzVector_from_python();
+
+#ifdef ROOT_HAS_PYROOT
+    convert_py_root_to_cpp_root<LorentzVector>();
+#endif
+
+    enum_<boost::log::trivial::severity_level>("log_level")
+            .value("trace", boost::log::trivial::severity_level::trace)
+            .value("debug", boost::log::trivial::severity_level::debug)
+            .value("info", boost::log::trivial::severity_level::info)
+            .value("warning", boost::log::trivial::severity_level::warning)
+            .value("error", boost::log::trivial::severity_level::error)
+            .value("fatal", boost::log::trivial::severity_level::fatal);
+
+    def("set_log_level", set_log_level);
+
+    class_<ParameterSet>("ParameterSet", no_init)
+            .def("exists", &ParameterSet::exists)
+            .def("getDouble", ParameterSet_get<double>, return_value_policy<copy_const_reference>())
+            .def("getInt", ParameterSet_get<int>, return_value_policy<copy_const_reference>())
+            .def("getString", ParameterSet_get<std::string>, return_value_policy<copy_const_reference>())
+            .def("getInputTag", ParameterSet_get<InputTag>, return_value_policy<copy_const_reference>())
+            .def("getParameterSet", ParameterSet_get<ParameterSet>, return_value_policy<copy_const_reference>())
+            .def("setDouble", ParameterSet_set<double>)
+            .def("setInt", ParameterSet_set<int>)
+            .def("setString", ParameterSet_set<std::string>)
+            .def("setInputTag", ParameterSet_set<InputTag>);
+
+    class_<Configuration>("Configuration", no_init)
+            .def("getGlobalParameters", &Configuration::getGlobalParameters,
+                 return_internal_reference<>())
+            .def("getCubaConfiguration", &Configuration::getCubaConfiguration,
+                 return_internal_reference<>());
+
+    class_<ConfigurationReader>("ConfigurationReader", init<std::string>())
+            .def("freeze", &ConfigurationReader::freeze)
+            .def("getGlobalParameters", &ConfigurationReader::getGlobalParameters,
+                 return_value_policy<reference_existing_object>())
+            .def("getCubaConfiguration", &ConfigurationReader::getCubaConfiguration,
+                 return_value_policy<reference_existing_object>());
+
+    enum_<MoMEMta::IntegrationStatus>("IntegrationStatus")
+            .value("ABORTED", MoMEMta::IntegrationStatus::ABORTED)
+            .value("ACCURACY_NOT_REACHED", MoMEMta::IntegrationStatus::ACCURARY_NOT_REACHED)
+            .value("DIM_OUT_OF_RANGE", MoMEMta::IntegrationStatus::DIM_OUT_OF_RANGE)
+            .value("FAILED", MoMEMta::IntegrationStatus::FAILED)
+            .value("NONE", MoMEMta::IntegrationStatus::NONE)
+            .value("SUCCESS", MoMEMta::IntegrationStatus::SUCCESS);
+
+    class_<MoMEMta>("MoMEMta", init<Configuration>())
+            .def("getIntegrationStatus", &MoMEMta::getIntegrationStatus)
+            //.def("getPool", &MoMEMta::getPool, return_value_policy<copy_const_reference>())
+            .def("computeWeights", MoMEMta_computeWeights)
+            .def("computeWeights", MoMEMta_computeWeights_MET)
+            .def("computeWeights", &MoMEMta::computeWeights, MoMEMta_computeWeights_overloads());
+}

--- a/tests/bindings/python/configuration.lua
+++ b/tests/bindings/python/configuration.lua
@@ -1,0 +1,167 @@
+function append(t1, t2)
+    for i = 1, #t2 do
+        t1[#t1 + 1] = t2[i]
+    end
+
+    return t1
+end
+
+inputs = {
+    'tf_p1::output',
+    'permutator::output/1',
+    'tf_p3::output',
+    'permutator::output/2',
+}
+
+parameters = {
+    energy = 13000.,
+    top_mass = 173.,
+    top_width = 1.491500,
+    W_mass = 80.419002,
+    W_width = 2.047600,
+}
+
+cuba = {
+    relative_accuracy = 0.01,
+    verbosity = 0,
+}
+
+BreitWignerGenerator.flatter_s13 = {
+    ps_point = add_dimension(),
+    mass = parameter('W_mass'),
+    width = parameter('W_width')
+}
+
+BreitWignerGenerator.flatter_s134 = {
+    ps_point = add_dimension(),
+    mass = parameter('top_mass'),
+    width = parameter('top_width')
+}
+
+BreitWignerGenerator.flatter_s25 = {
+    ps_point = add_dimension(),
+    mass = parameter('W_mass'),
+    width = parameter('W_width')
+}
+
+BreitWignerGenerator.flatter_s256 = {
+    ps_point = add_dimension(),
+    mass = parameter('top_mass'),
+    width = parameter('top_width')
+}
+
+GaussianTransferFunction.tf_p1 = {
+    ps_point = add_dimension(),
+    reco_particle = 'input::particles/1',
+    sigma = 0.05,
+}
+
+GaussianTransferFunction.tf_p2 = {
+    ps_point = add_dimension(),
+    reco_particle = 'input::particles/2',
+    sigma = 0.10,
+}
+
+GaussianTransferFunction.tf_p3 = {
+    ps_point = add_dimension(),
+    reco_particle = 'input::particles/3',
+    sigma = 0.05,
+}
+
+GaussianTransferFunction.tf_p4 = {
+    ps_point = add_dimension(),
+    reco_particle = 'input::particles/4',
+    sigma = 0.10,
+}
+
+-- Declare module before the permutator to test read-access in the pool
+-- for non-existant values.
+BlockD.blockd = {
+    inputs = inputs,
+    pT_is_met = true,
+    s13 = 'flatter_s13::s',
+    s134 = 'flatter_s134::s',
+    s25 = 'flatter_s25::s',
+    s256 = 'flatter_s256::s',
+}
+
+Permutator.permutator = {
+    ps_point = add_dimension(),
+    inputs = {
+        'tf_p2::output',
+        'tf_p4::output',
+    }
+}
+
+-- Loop over block solutions
+
+Looper.looper = {
+    solutions = "blockd::solutions",
+    path = Path("boost", "ttbar", "dmem", "integrand")
+}
+
+BuildInitialState.boost = {
+    solution = 'looper::solution',
+    do_transverse_boost = true,
+    particles = inputs
+}
+
+jacobians = { 'flatter_s13::jacobian', 'flatter_s134::jacobian', 'flatter_s25::jacobian', 'flatter_s256::jacobian' }
+append(jacobians, { 'tf_p1::TF_times_jacobian', 'tf_p2::TF_times_jacobian', 'tf_p3::TF_times_jacobian', 'tf_p4::TF_times_jacobian' })
+
+
+MatrixElement.ttbar = {
+    pdf = 'CT10nlo',
+    pdf_scale = parameter('top_mass'),
+    matrix_element = 'pp_ttx_fully_leptonic',
+    matrix_element_parameters = {
+        card = '../MatrixElements/Cards/param_card.dat'
+    },
+    initialState = 'boost::partons',
+    invisibles = {
+        input = 'looper::solution',
+        ids = {
+            {
+                pdg_id = 12,
+                me_index = 2,
+            },
+
+            {
+                pdg_id = -14,
+                me_index = 5,
+            }
+        }
+    },
+    particles = {
+        inputs = inputs,
+        ids = {
+            {
+                pdg_id = -11,
+                me_index = 1,
+            },
+
+            {
+                pdg_id = 5,
+                me_index = 3,
+            },
+
+            {
+                pdg_id = 13,
+                me_index = 4,
+            },
+
+            {
+                pdg_id = -5,
+                me_index = 6,
+            },
+        }
+    },
+    jacobians = jacobians
+}
+
+DoubleSummer.integrand = {
+    input = "ttbar::output"
+}
+
+-- End of loop
+integrand("integrand::sum")

--- a/tests/bindings/python/integration_tests.py
+++ b/tests/bindings/python/integration_tests.py
@@ -1,0 +1,57 @@
+#! /bin/env python
+
+import momemta
+import unittest
+
+class IntegrationTest(unittest.TestCase):
+    def setUp(self):
+        momemta.set_log_level(momemta.log_level.error)
+        self.reader = momemta.ConfigurationReader("../examples/tt_fullyleptonic.lua")
+
+        # Change number of iterations for cuba
+        cuba = self.reader.getCubaConfiguration()
+        cuba.setInt("verbosity", 0)
+        cuba.setInt("max_eval", 2000)
+        cuba.setInt("n_start", 500)
+        cuba.setDouble("relative_accuracy", 0.5)
+
+        self.runner = momemta.MoMEMta(self.reader.freeze())
+
+    def test_pyroot(self):
+        import ROOT
+        LorentzVector = ROOT.Math.LorentzVector('ROOT::Math::PxPyPzE4D<double>')
+
+        # List of LorentzVector
+        p3 = LorentzVector(16.171895980835, -13.7919054031372, -3.42997527122497, 21.5293197631836)
+        p4 = LorentzVector(-55.7908325195313, -111.59294128418, -122.144721984863, 174.66259765625)
+        p5 = LorentzVector(-18.9018573760986, 10.0896110534668, -0.602926552295686, 21.4346446990967)
+        p6 = LorentzVector(71.3899612426758, 96.0094833374023, -77.2513122558594, 142.492813110352)
+
+        result = self.runner.computeWeights([p3, p4, p5, p6])
+        self.assertEqual(self.runner.getIntegrationStatus(), momemta.IntegrationStatus.SUCCESS)
+
+        self.assertEqual(len(result), 1)
+
+        result = result[0]
+        self.assertAlmostEquals(result[0], 4.4954322e-21)
+        self.assertAlmostEquals(result[1], 2.1120765e-21)
+
+    def test_list(self):
+
+        # Plain list as LorentzVector
+        p3 = [16.171895980835, -13.7919054031372, -3.42997527122497, 21.5293197631836]
+        p4 = [-55.7908325195313, -111.59294128418, -122.144721984863, 174.66259765625]
+        p5 = [-18.9018573760986, 10.0896110534668, -0.602926552295686, 21.4346446990967]
+        p6 = [71.3899612426758, 96.0094833374023, -77.2513122558594, 142.492813110352]
+
+        result = self.runner.computeWeights([p3, p4, p5, p6])
+        self.assertEqual(self.runner.getIntegrationStatus(), momemta.IntegrationStatus.SUCCESS)
+
+        self.assertEqual(len(result), 1)
+
+        result = result[0]
+        self.assertAlmostEquals(result[0], 4.4954322e-21)
+        self.assertAlmostEquals(result[1], 2.1120765e-21)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/bindings/python/integration_tests.py
+++ b/tests/bindings/python/integration_tests.py
@@ -1,12 +1,18 @@
 #! /bin/env python
 
+import argparse
 import momemta
 import unittest
+import sys
+
+CONFIGURATION_FILE = ''
 
 class IntegrationTest(unittest.TestCase):
     def setUp(self):
+        global CONFIGURATION_FILE
+
         momemta.set_log_level(momemta.log_level.error)
-        self.reader = momemta.ConfigurationReader("../examples/tt_fullyleptonic.lua")
+        self.reader = momemta.ConfigurationReader(CONFIGURATION_FILE)
 
         # Change number of iterations for cuba
         cuba = self.reader.getCubaConfiguration()
@@ -54,4 +60,11 @@ class IntegrationTest(unittest.TestCase):
         self.assertAlmostEquals(result[1], 2.1120765e-21)
 
 if __name__ == '__main__':
-    unittest.main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('configuration', type=str)
+
+    options, args = parser.parse_known_args()
+
+    CONFIGURATION_FILE = options.configuration
+
+    unittest.main(argv=sys.argv[:1] + args)

--- a/travis/get-lhapdf.sh
+++ b/travis/get-lhapdf.sh
@@ -13,8 +13,21 @@ cd ${BUNDLE}
 
 # Fix 'lhapdf-config' which hardcode path
 sed -i "s#/vagrant/builds/LHAPDF-6.1.6_Python-2.7_gcc-4.9.3_Ubuntu_14.04_x86_64#$PWD#" bin/lhapdf-config
+sed -i "s#/vagrant/builds/LHAPDF-6.1.6_Python-2.7_gcc-4.9.3_Ubuntu_14.04_x86_64#$PWD#" bin/lhapdf
 
 export PATH="$PWD/bin:$PATH"
 export LD_LIBRARY_PATH="$PWD/lib:$LB_LIBRARY_PATH"
+export PYTHONPATH="$PWD/lib/python2.7/site-packages:$PYTHONPATH"
+
+# Install CT10nlo
+
+pushd share/LHAPDF
+
+wget http://www.hepforge.org/archive/lhapdf/pdfsets/6.1/CT10nlo.tar.gz
+tar xf CT10nlo.tar.gz
+
+popd
+
+export LHAPDF_DATA_PATH="$PWD/share/LHAPDF"
 
 cd ../../..


### PR DESCRIPTION
This PR introduce python bindings for MoMEMta, allowing to compute MEM weights directly from python :) Not all MoMEMta is exposed to python, but enough is to actually:
 - Parse configuration file
 - Edit parameters
 - Compute weights

Included in this PR is an integration test in python, computing weights and checking it's correct.

Bindings are not built by default, you have to add the `-DPYTHON_BINDINGS=ON` flag when running cmake. Python and boost::python are both needed for the bindings. If they are not available, bindings are not built. Also, if one want support for pyroot, then ROOT has obviously to be built with pyroot. If it's not the case, bindings are built, but without pyroot support.

TODO:
 - ~~Install target is missing for the python bindings~~ done