### PR TITLE
Fix cuba Fork in release mode

### DIFF
--- a/external/cuba/src/common/Fork.c
+++ b/external/cuba/src/common/Fork.c
@@ -95,9 +95,13 @@ Extern void SUFFIX(cubafork)(Spin **pspin)
   for( core = -spin->spec.naccel; core < spin->spec.ncores; ++core ) {
     int fd[2];
     pid_t pid;
-    assert(
-      socketpair(AF_LOCAL, SOCK_STREAM, 0, fd) != -1 &&
-      (pid = fork()) != -1 );
+    if (socketpair(AF_LOCAL, SOCK_STREAM, 0, fd) == -1)
+      perror("Error while opening socket");
+
+    pid = fork();
+    if (pid == -1)
+      perror("Error while forking process");
+
     if( pid == 0 ) {
       close(fd[0]);
       free(spin);


### PR DESCRIPTION
When building in release mode, `assert` is never executed, and so
the process is never forked.

Backport of #92 