### PR TITLE
Fix matrix element card parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
  - Cuba forking mode was broken when building in release mode (with `-DCMAKE_RELEASE_TYPE=Release`).
+ - SLHA card reader (matrix element parameter cards) retrieved from MadGraph was broken.

--- a/core/src/SLHAReader.cc
+++ b/core/src/SLHAReader.cc
@@ -1,10 +1,23 @@
 #include <algorithm>
 #include <fstream>
 #include <iostream>
+#include <regex>
 
 #include <momemta/SLHAReader.h>
 
 namespace SLHA {
+
+std::vector<std::string> parse_line_elements(const std::string& line, char delimiter=' ') {
+    std::vector<std::string> elements;
+    std::string temp;
+    std::stringstream linestr(line);
+    while (getline(linestr, temp, delimiter)) {
+        if (temp == std::string(&delimiter, 1))
+            continue;
+        elements.push_back(temp);
+    }
+    return elements;
+}
 
 class invalid_card_error: public std::runtime_error {
     using std::runtime_error::runtime_error;
@@ -42,70 +55,82 @@ Reader::Reader(const std::string& file_name /* = ""*/) {
 }
 
 void Reader::read_slha_file(const std::string& file_name) {
-    std::ifstream param_card;
-    param_card.open(file_name.c_str(), std::ifstream::in);
-    if (!param_card.good())
+    std::ifstream param_card(file_name.c_str(), std::ifstream::in);
+    if (!param_card.is_open())
         throw invalid_card_error("Error while opening param card");
-    char buf[200];
     std::string line;
     std::string block("");
 
-    while (param_card.good()) {
-        param_card.getline(buf, 200);
-        line = buf;
-        // Change to lowercase
-        std::transform(line.begin(), line.end(), line.begin(), ::tolower);
-        if (line != "" && line[0] != '#') {
-            if (block != "") {
-                // Look for double index blocks
-                int dindex1 = 0, dindex2 = 0;
-                double value = 0;
-                std::stringstream linestr2(line);
-                if (linestr2 >> dindex1 >> dindex2 >> value) {
-                    set_block_entry(block, {dindex1, dindex2}, value);
-                    // Done with this line, read next
-                    continue;
-                }
-                std::stringstream linestr1(line);
-                // Look for single index blocks
-                if (linestr1 >> dindex1 >> value) {
-                    std::vector<int> indices {dindex1};
-                    set_block_entry(block, indices, value);
-                    // Done with this line, read next
-                    continue;
-                }
-            }
+    try {
+
+        while (std::getline(param_card, line)) {
+            // Change to lowercase
+            std::transform(line.begin(), line.end(), line.begin(), ::tolower);
+            // Remove comments
+            line = std::regex_replace(line, std::regex("#.*"), "");
+            // Remove leading, trailing and duplicate whitespaces
+            line = std::regex_replace(line, std::regex("^ *| *$"), "");
+            line = std::regex_replace(line, std::regex(" +"), " ");
+            
+            if (line == "")
+                continue;
+            
             // Look for block
             if (line.find("block ") != line.npos) {
                 line = line.substr(6);
-                // Get rid of spaces between block and block name
-                while (line[0] == ' ')
-                    line = line.substr(1);
-                // Now find end of block name
+                // Find end of block name
                 size_t space_pos = line.find(' ');
                 if (space_pos != line.npos)
                     line = line.substr(0, space_pos);
                 block = line;
                 continue;
             }
-            // Look for decay
+            // Look for decay (not part of a block)
             if (line.find("decay ") == 0) {
                 line = line.substr(6);
                 block = "";
-                std::stringstream linestr(line);
-                int pdg_code;
-                double value;
-                if (linestr >> pdg_code >> value)
-                    set_block_entry("decay", pdg_code, value);
-                else
+                auto elements = parse_line_elements(line);
+                if (elements.size() == 2) {
+                    int pdg_id = std::stoi(elements[0]);
+                    double value = std::stod(elements[1]);
+                    set_block_entry("decay", pdg_id, value);
+                } else {
                     throw invalid_card_error("Wrong format for decay block " + line);
+                }
                 continue;
             }
+            // We have a block, now read this block's entries line by line
+            if (block != "") {
+                auto elements = parse_line_elements(line);
+                // Look for double index blocks
+                if (elements.size() == 3) {
+                    int id1 = std::stoi(elements[0]);
+                    int id2 = std::stoi(elements[1]);
+                    double value = std::stod(elements[2]);
+                    set_block_entry(block, { id1, id2 }, value);
+                    // Done with this line, read next
+                    continue;
+                } else if (elements.size() == 2) {
+                // Look for single index blocks
+                    int id = std::stoi(elements[0]);
+                    double value = std::stod(elements[1]);
+                    set_block_entry(block, { id }, value);
+                    // Done with this line, read next
+                    continue;
+                } else {
+                    throw invalid_card_error("Wrong format for entry in block " + block + "; line: " + line);
+                }
+            }
         }
-    }
 
-    if (_blocks.size() == 0)
-        throw invalid_card_error("No information read from SLHA card");
+        if (_blocks.size() == 0)
+            throw invalid_card_error("No information read from SLHA card");
+
+    // End try
+    } catch(std::exception &e) {
+        param_card.close();
+        throw e;
+    }
 
     param_card.close();
 }


### PR DESCRIPTION
The piece of code retrieved from MadGraph supposed to parse the param cards doesn't work: for all parameters but those flagged as "decay" (ie widths), the reader would parse the line incorrectly, and the values in the card would not be used when instanciating a matrix element (default values are then used instead).

This should fix it. I've checked that I know get different values for the weight when changing ie. the top mass in the card.

It'll have to be backported to v0.1.