### PR TITLE
Add a way for the user to inject variables into the lua configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - Main block A
  - Modules to only evaluate transfer functions (without integrating over anything): BinnedTransferFunctionOnEnergyEvaluator, GaussianTransferFunctionOnEnergyEvaluator
  - Matrix element parameters can now be edited from the configuration file.
+ - `ConfigurationReader` constructor now accepts an optional second argument allowing the definition of variables accessible from the lua configuration. 
 
 ### Changed
  - The way to handle multiple solutions coming from blocks has changed. A module is no longer responsible for looping over the solutions itself, this role is delegated to the `Looper` module. As a consequence, most of the module were rewritten to handle this change. See this [pull request](https://github.com/MoMEMta/MoMEMta/pull/69) and [this one](https://github.com/MoMEMta/MoMEMta/pull/91) for a more technical description, and this [documentation entry](http://momemta.github.io/) for more details

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,8 @@ set(MOMEMTA_SOURCES
     "core/src/SLHAReader.cc"
     "core/src/Solution.cc"
     "core/src/Utils.cc"
+    "core/src/lua/LazyTable.cc"
+    "core/src/lua/ParameterSetParser.cc"
     "core/src/lua/Path.cc"
     "core/src/lua/Types.cc"
     "core/src/lua/utils.cc"

--- a/core/include/lua/LazyTable.h
+++ b/core/include/lua/LazyTable.h
@@ -1,0 +1,81 @@
+/*
+ *  MoMEMta: a modular implementation of the Matrix Element Method
+ *  Copyright (C) 2016  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <momemta/ParameterSet.h>
+
+#include <lua/utils.h>
+
+namespace lua {
+
+/**
+ * \brief Lazy table field in lua (delayed table access)
+ *
+ * It's a wrapper around table's field access. Evaluation of this lazy value means accessing the field of the table.
+ */
+struct LazyTableField : public Lazy {
+    std::string table_name; ///< The name of the global table
+    std::string key; ///< The name of the field inside the table to retrieve when evaluated
+
+    virtual boost::any operator()() const override;
+
+    /**
+     * \brief Ensure the global table referenced by this `struct` exist. If not, create it.
+     */
+    void ensure_created();
+
+    /**
+     * \brief Replace the value of the table field by a new one
+     */
+    void set(const boost::any& value);
+
+    LazyTableField(lua_State *L, const std::string& table_name, const std::string& key);
+};
+
+/** \brief A specialization of ParameterSet for lazy loading of lua tables
+ *
+ * This class is used to represent global tables that can be modified **after** the parsing of the configuration file (like the global `parameters` table). This means that each field of the table *must* have a delayed evaluation (see lua::LazyTableField).
+ *
+ * Actual evaluation of the fields of the table happens during the freezing of this ParameterSet.
+ *
+ */
+
+class LazyTable: public ParameterSet {
+    friend class ConfigurationReader;
+
+public:
+    LazyTable(std::shared_ptr<lua_State> L, const std::string& name);
+    virtual LazyTable* clone() const override;
+
+protected:
+    virtual void create(const std::string& name, const boost::any& value) override;
+    virtual void setInternal(const std::string& name, Element& element, const boost::any& value) override;
+
+    virtual bool lazy() const override;
+
+    virtual void freeze() override;
+
+private:
+    std::shared_ptr<lua_State> m_lua_state;
+};
+
+}

--- a/core/include/lua/ParameterSetParser.h
+++ b/core/include/lua/ParameterSetParser.h
@@ -1,0 +1,35 @@
+/*
+ *  MoMEMta: a modular implementation of the Matrix Element Method
+ *  Copyright (C) 2016  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <momemta/ParameterSet.h>
+
+struct lua_State;
+
+class ParameterSetParser {
+public:
+
+    /**
+     * \brief Convert a lua table to a ParameterSet
+     *
+     * \param L the lua state
+     * \param index The index on the stack of the table to parse
+     */
+    static void parse(ParameterSet& p, lua_State* L, int index);
+};

--- a/core/include/lua/utils.h
+++ b/core/include/lua/utils.h
@@ -87,30 +87,6 @@ namespace lua {
     };
 
     /**
-     * \brief Lazy table field in lua (delayed table access)
-     *
-     * It's a wrapper around table's field access. Evaluation of this lazy value means accessing the field of the table.
-     */
-    struct LazyTableField: public Lazy {
-        std::string table_name; ///< The name of the global table
-        std::string key; ///< The name of the field inside the table to retrieve when evaluated
-
-        virtual boost::any operator() () const override;
-
-        /**
-         * \brief Ensure the global table referenced by this `struct` exist. If not, create it.
-         */
-        void ensure_created();
-
-        /**
-         * \brief Replace the value of the table field by a new one
-         */
-        void set(const boost::any& value);
-
-        LazyTableField(lua_State* L, const std::string& table_name, const std::string& key);
-    };
-
-    /**
      * \brief Extract the type of a lua value
      *
      * \param L The current lua state
@@ -269,7 +245,7 @@ namespace lua {
      * released using the `lua_close` function.
      */
     std::shared_ptr<lua_State> init_runtime(ILuaCallback* callback);
-   
+
     /** \brief Define Lua function to generate Cuba phase-space point input-tags
      *
      * \param L The current lua state

--- a/core/include/lua/utils.h
+++ b/core/include/lua/utils.h
@@ -8,6 +8,7 @@
 #include <lua.hpp>
 
 class ILuaCallback;
+class ParameterSet;
 
 /*! \brief Utility functions related to lua configuration file parsing
  *
@@ -256,4 +257,14 @@ namespace lua {
      * \return always 1
      */
     int generate_cuba_inputtag(lua_State* L);
+
+    /**
+     * \brief Inject parameters into the current lua state
+     *
+     * For each parameter inside \p parameters, a global variable is created inside the lua state.
+     *
+     * \param L The lua state
+     * \param parameters Parameters to inject into the lua state
+     */
+    void inject_parameters(lua_State* L, const ParameterSet& parameters);
 }

--- a/core/src/ConfigurationReader.cc
+++ b/core/src/ConfigurationReader.cc
@@ -29,11 +29,19 @@
 
 #include <lua/LazyTable.h>
 #include <lua/ParameterSetParser.h>
+#include <lua/utils.h>
 
-ConfigurationReader::ConfigurationReader(const std::string& file) {
+ConfigurationReader::ConfigurationReader(const std::string& file) :
+        ConfigurationReader(file, ParameterSet()) {
+    // Empty
+}
+
+ConfigurationReader::ConfigurationReader(const std::string& file, const ParameterSet& parameters) {
 
     LOG(debug) << "Parsing LUA configuration from " << file;
     lua_state = lua::init_runtime(this);
+
+    lua::inject_parameters(lua_state.get(), parameters);
 
     // Parse file
     if (luaL_dofile(lua_state.get(), file.c_str())) {

--- a/core/src/ParameterSet.cc
+++ b/core/src/ParameterSet.cc
@@ -18,9 +18,9 @@
 
 #include <momemta/ParameterSet.h>
 
-#include <momemta/Logging.h>
 #include <momemta/Unused.h>
 
+#include <lua/LazyTable.h>
 #include <lua/utils.h>
 
 ParameterSet::ParameterSet(const std::string& module_type, const std::string& module_name) {
@@ -28,40 +28,8 @@ ParameterSet::ParameterSet(const std::string& module_type, const std::string& mo
     m_set.emplace("@name", Element(module_name));
 }
 
-void ParameterSet::parse(lua_State* L, int index) {
-
-    LOG(trace) << "[parse] >> stack size = " << lua_gettop(L);
-    size_t absolute_index = lua::get_index(L, index);
-
-    lua_pushnil(L);
-    while (lua_next(L, absolute_index) != 0) {
-
-        std::string key = lua_tostring(L, -2);
-
-        LOG(trace) << "[parse] >> key = " << key;
-
-        try {
-            boost::any value;
-            bool lazy = false;
-            std::tie(value, lazy) = parseItem(key, L, -1);
-
-            m_set.emplace(key, Element(value, lazy));
-        } catch(...) {
-            LOG(fatal) << "Exception while trying to parse parameter " << getModuleType() << "." << getModuleName() << "::" << key;
-            lua_pop(L, 1);
-            std::rethrow_exception(std::current_exception());
-        }
-
-        lua_pop(L, 1);
-    }
-
-    LOG(trace) << "[parse] << stack size = " << lua_gettop(L);
-}
-
-std::pair<boost::any, bool> ParameterSet::parseItem(const std::string& key, lua_State* L, int index) {
-    UNUSED(key);
-
-    return lua::to_any(L, index);
+bool ParameterSet::lazy() const {
+    return false;
 }
 
 bool ParameterSet::exists(const std::string& name) const {
@@ -129,51 +97,4 @@ std::vector<std::string> ParameterSet::getNames() const {
     }
 
     return names;
-}
-
-// ---------
-
-LazyParameterSet::LazyParameterSet(std::shared_ptr<lua_State> L, const std::string& name):
-    ParameterSet("table", name) {
-    m_lua_state = L;
-}
-
-std::pair<boost::any, bool> LazyParameterSet::parseItem(const std::string& key, lua_State* L, int index) {
-    UNUSED(index);
-
-    return std::make_pair(lua::LazyTableField(L, getModuleName(), key), true);
-}
-
-void LazyParameterSet::create(const std::string& name, const boost::any& value) {
-
-    lua::LazyTableField lazyField = lua::LazyTableField(m_lua_state.get(), getModuleName(), name);
-    lazyField.ensure_created();
-    lazyField.set(value);
-
-    m_set.emplace(name, Element(lazyField, true));
-}
-
-void LazyParameterSet::setInternal(const std::string& name, Element& element, const boost::any& value) {
-
-    // We know that this set is not frozen, so *all* the items in the map
-    // are actually lazy reference to lua table values.
-    // Instead of editing directly the value, we edit the value of the global table
-    // directly in lua user-space
-    UNUSED(name);
-
-    assert(element.lazy);
-    assert(element.value.type() == typeid(lua::LazyTableField));
-
-    boost::any_cast<lua::LazyTableField&>(element.value).set(value);
-}
-
-void LazyParameterSet::freeze() {
-    ParameterSet::freeze();
-
-    // Release lua_State. We don't need it anymore
-    m_lua_state.reset();
-}
-
-LazyParameterSet* LazyParameterSet::clone() const {
-    return new LazyParameterSet(*this);
 }

--- a/core/src/ParameterSet.cc
+++ b/core/src/ParameterSet.cc
@@ -28,6 +28,14 @@ ParameterSet::ParameterSet(const std::string& module_type, const std::string& mo
     m_set.emplace("@name", Element(module_name));
 }
 
+const boost::any& ParameterSet::rawGet(const std::string& name) const {
+    auto value = m_set.find(name);
+    if (value == m_set.end())
+        throw not_found_error("Parameter '" + name + "' not found.");
+
+    return value->second.value;
+}
+
 bool ParameterSet::lazy() const {
     return false;
 }

--- a/core/src/lua/LazyTable.cc
+++ b/core/src/lua/LazyTable.cc
@@ -1,0 +1,134 @@
+/*
+ *  MoMEMta: a modular implementation of the Matrix Element Method
+ *  Copyright (C) 2016  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lua/LazyTable.h>
+
+#include <momemta/Logging.h>
+#include <momemta/Unused.h>
+
+#include <lua/utils.h>
+
+namespace lua {
+
+LazyTableField::LazyTableField(lua_State *L, const std::string& table_name, const std::string& key) :
+        Lazy(L) {
+    this->table_name = table_name;
+    this->key = key;
+}
+
+void LazyTableField::ensure_created() {
+    // Push the table on the stack. Stack +1
+    int type = lua_getglobal(L, table_name.c_str());
+    // Discard the result. Stack -1
+    lua_pop(L, 1);
+
+    // Already existing
+    if (type != LUA_TNIL)
+        return;
+
+    // Create a new table. Stack +1
+    lua_newtable(L);
+    // Set it global. Stack -1
+    lua_setglobal(L, table_name.c_str());
+}
+
+boost::any LazyTableField::operator()() const {
+    LOG(trace) << "[LazyTableField::operator()] >> stack size = " << lua_gettop(L);
+
+    // Push the table on the stack. Stack +1
+    lua_getglobal(L, table_name.c_str());
+
+    // Push the requested field from the table to the stack. Stack +1
+    lua_getfield(L, -1, key.c_str());
+
+    boost::any value;
+    bool lazy = false;
+    std::tie(value, lazy) = to_any(L, -1);
+    assert(!lazy);
+
+    // Pop the field and the table from the stack. Stack -2
+    lua_pop(L, 2);
+
+    LOG(trace) << "[LazyTableField::operator()] << stack size = " << lua_gettop(L);
+
+    return value;
+}
+
+void LazyTableField::set(const boost::any& value) {
+    LOG(trace) << "[LazyTableField::set] >> stack size = " << lua_gettop(L);
+
+    // Push the table on the stack. Stack +1
+    lua_getglobal(L, table_name.c_str());
+
+    // Push the value to the stack. Stack +1
+    lua::push_any(L, value);
+
+    // Pop the requested field from the stack and assign it to the table. Stack -1
+    lua_setfield(L, -2, key.c_str());
+
+    // Pop the table from the stack. Stack -1
+    lua_pop(L, 1);
+
+    LOG(trace) << "[LazyTableField::set] << stack size = " << lua_gettop(L);
+}
+
+LazyTable::LazyTable(std::shared_ptr<lua_State> L, const std::string& name):
+        ParameterSet("table", name) {
+    m_lua_state = L;
+}
+
+bool LazyTable::lazy() const {
+    return true;
+}
+
+void LazyTable::create(const std::string& name, const boost::any& value) {
+
+    lua::LazyTableField lazyField = lua::LazyTableField(m_lua_state.get(), getModuleName(), name);
+    lazyField.ensure_created();
+    lazyField.set(value);
+
+    m_set.emplace(name, Element(lazyField, true));
+}
+
+void LazyTable::setInternal(const std::string& name, Element& element, const boost::any& value) {
+
+    // We know that this set is not frozen, so *all* the items in the map
+    // are actually lazy reference to lua table values.
+    // Instead of editing directly the value, we edit the value of the global table
+    // directly in lua user-space
+    UNUSED(name);
+
+    assert(element.lazy);
+    assert(element.value.type() == typeid(lua::LazyTableField));
+
+    boost::any_cast<lua::LazyTableField&>(element.value).set(value);
+}
+
+void LazyTable::freeze() {
+    ParameterSet::freeze();
+
+    // Release lua_State. We don't need it anymore
+    m_lua_state.reset();
+}
+
+LazyTable* LazyTable::clone() const {
+    return new LazyTable(*this);
+}
+
+
+}

--- a/core/src/lua/ParameterSetParser.cc
+++ b/core/src/lua/ParameterSetParser.cc
@@ -1,0 +1,59 @@
+/*
+ *  MoMEMta: a modular implementation of the Matrix Element Method
+ *  Copyright (C) 2016  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lua/ParameterSetParser.h>
+
+#include <momemta/Logging.h>
+
+#include <lua/LazyTable.h>
+#include <lua/utils.h>
+
+void ParameterSetParser::parse(ParameterSet& p, lua_State* L, int index) {
+
+    LOG(trace) << "[parse] >> stack size = " << lua_gettop(L);
+    size_t absolute_index = lua::get_index(L, index);
+
+    lua_pushnil(L);
+    while (lua_next(L, absolute_index) != 0) {
+
+        std::string key = lua_tostring(L, -2);
+
+        LOG(trace) << "[parse] >> key = " << key;
+
+        try {
+            boost::any value;
+            bool lazy = p.lazy();
+
+            if (lazy) {
+                value = lua::LazyTableField(L, p.getModuleName(), key);
+            } else {
+                std::tie(value, lazy) = lua::to_any(L, -1);
+            }
+
+            p.m_set.emplace(key, ParameterSet::Element(value, lazy));
+        } catch(...) {
+            LOG(fatal) << "Exception while trying to parse parameter " << p.getModuleType() << "." << p.getModuleName() << "::" << key;
+            lua_pop(L, 1);
+            std::rethrow_exception(std::current_exception());
+        }
+
+        lua_pop(L, 1);
+    }
+
+    LOG(trace) << "[parse] << stack size = " << lua_gettop(L);
+}

--- a/core/src/lua/utils.cc
+++ b/core/src/lua/utils.cc
@@ -26,6 +26,7 @@
 #include <momemta/Utils.h>
 
 #include <LibraryManager.h>
+#include <lua/ParameterSetParser.h>
 #include <lua/Path.h>
 #include <lua/Types.h>
 
@@ -69,68 +70,6 @@ namespace lua {
         LOG(trace) << "[LazyFunction::operator()] << stack size = " << lua_gettop(L);
 
         return value;
-    }
-
-    LazyTableField::LazyTableField(lua_State* L, const std::string& table_name, const std::string& key):
-        Lazy(L) {
-        this->table_name = table_name;
-        this->key = key;
-    }
-
-    void LazyTableField::ensure_created() {
-        // Push the table on the stack. Stack +1
-        int type = lua_getglobal(L, table_name.c_str());
-        // Discard the result. Stack -1
-        lua_pop(L, 1);
-
-        // Already existing
-        if (type != LUA_TNIL)
-            return;
-
-        // Create a new table. Stack +1
-        lua_newtable(L);
-        // Set it global. Stack -1
-        lua_setglobal(L, table_name.c_str());
-    }
-
-    boost::any LazyTableField::operator() () const {
-        LOG(trace) << "[LazyTableField::operator()] >> stack size = " << lua_gettop(L);
-
-        // Push the table on the stack. Stack +1
-        lua_getglobal(L, table_name.c_str());
-
-        // Push the requested field from the table to the stack. Stack +1
-        lua_getfield(L, -1, key.c_str());
-
-        boost::any value;
-        bool lazy = false;
-        std::tie(value, lazy) = to_any(L, -1);
-        assert(!lazy);
-
-        // Pop the field and the table from the stack. Stack -2
-        lua_pop(L, 2);
-
-        LOG(trace) << "[LazyTableField::operator()] << stack size = " << lua_gettop(L);
-
-        return value;
-    }
-
-    void LazyTableField::set(const boost::any& value) {
-        LOG(trace) << "[LazyTableField::set] >> stack size = " << lua_gettop(L);
-
-        // Push the table on the stack. Stack +1
-        lua_getglobal(L, table_name.c_str());
-
-        // Push the value to the stack. Stack +1
-        lua::push_any(L, value);
-
-        // Pop the requested field from the stack and assign it to the table. Stack -1
-        lua_setfield(L, -2, key.c_str());
-
-        // Pop the table from the stack. Stack -1
-        lua_pop(L, 1);
-
-        LOG(trace) << "[LazyTableField::set] << stack size = " << lua_gettop(L);
     }
 
     Type type(lua_State* L, int index) {
@@ -292,7 +231,7 @@ namespace lua {
 
                 } else {
                     ParameterSet cfg;
-                    cfg.parse(L, absolute_index);
+                    ParameterSetParser::parse(cfg, L, absolute_index);
                     result = cfg;
                 }
                 LOG(trace) << "[to_any::table] << stack size = " << lua_gettop(L);
@@ -493,7 +432,7 @@ namespace lua {
 
         void* cfg_ptr = lua_touserdata(L, lua_upvalueindex(1));
         ILuaCallback* callback = static_cast<ILuaCallback*>(cfg_ptr);
-        
+
         for(size_t i = 1; i <= size_t(n); i++) {
             std::string input_tag = luaL_checkstring(L, i);
             if (!InputTag::isInputTag(input_tag)) {
@@ -521,7 +460,7 @@ namespace lua {
 
         // Input tag is return value of the function
         push_any(L, index_tag);
-        
+
         // Add an integration dimension in the configuration
         void* cfg_ptr = lua_touserdata(L, lua_upvalueindex(2));
         ILuaCallback* callback = static_cast<ILuaCallback*>(cfg_ptr);
@@ -564,7 +503,7 @@ namespace lua {
 
         // Register existing modules
         lua::register_modules(L.get(), callback);
-    
+
         return L;
     }
 }

--- a/core/src/lua/utils.cc
+++ b/core/src/lua/utils.cc
@@ -506,4 +506,12 @@ namespace lua {
 
         return L;
     }
+
+    void inject_parameters(lua_State* L, const ParameterSet& parameters) {
+        for (const auto& parameter: parameters.getNames()) {
+            LOG(debug) << "Injecting parameter " << parameter;
+            lua::push_any(L, parameters.rawGet(parameter));
+            lua_setglobal(L, parameter.c_str());
+        }
+    }
 }

--- a/examples/tt_fullyleptonic.cc
+++ b/examples/tt_fullyleptonic.cc
@@ -35,7 +35,11 @@ int main(int argc, char** argv) {
 
     logging::set_level(boost::log::trivial::debug);
 
-    ConfigurationReader configuration("../examples/tt_fullyleptonic.lua");
+    ParameterSet lua_parameters;
+    lua_parameters.set("USE_TF", true);
+    lua_parameters.set("USE_PERM", true);
+
+    ConfigurationReader configuration("../examples/tt_fullyleptonic.lua", lua_parameters);
 
     // Change top mass
     configuration.getGlobalParameters().set("top_mass", 173.);

--- a/examples/tt_fullyleptonic.lua
+++ b/examples/tt_fullyleptonic.lua
@@ -18,7 +18,7 @@ end
 load_modules('libempty_module.so')
 load_modules('MatrixElements/dummy/libme_dummy.so')
 
-USE_TF = true
+-- Note: USE_PERM and USE_TF are defined in the C++ code and injected in lua before parsing this file
 
 if USE_TF then
     -- With transfer functions
@@ -37,8 +37,6 @@ else
         'input::particles/4',
     }
 end
-
-USE_PERM = true
 
 if USE_PERM then
   -- Use permutator module to permutate input particles 0 and 2 using the MC
@@ -65,7 +63,7 @@ cuba = {
     relative_accuracy = 0.01,
     verbosity = 3,
 }
- 
+
 BreitWignerGenerator.flatter_s13 = {
     -- add_dimension() generates an input tag of type `cuba::ps_points/i`
     -- where `i` is automatically incremented each time the function is called.

--- a/include/momemta/ConfigurationReader.h
+++ b/include/momemta/ConfigurationReader.h
@@ -45,6 +45,7 @@ struct lua_State;
 class ConfigurationReader: public ILuaCallback {
     public:
         ConfigurationReader(const std::string&);
+        ConfigurationReader(const std::string&, const ParameterSet&);
 
         virtual void onModuleDeclared(const std::string& type, const std::string& name) override;
         virtual void onIntegrandDeclared(const InputTag& tag) override;

--- a/include/momemta/ParameterSet.h
+++ b/include/momemta/ParameterSet.h
@@ -110,6 +110,15 @@ class ParameterSet {
             }
         }
 
+        /**
+         * Retrieve a raw value from this ParameterSet.
+         *
+         * @param name The name of the parameter
+         * @return The raw value of the parameter. A `not_found_error` exception is thrown if \p parameter does not
+         * exist in this set.
+         */
+        const boost::any& rawGet(const std::string& name) const;
+
         bool exists(const std::string& name) const;
         template<typename T> bool existsAs(const std::string& name) const {
             auto value = m_set.find(name);

--- a/tests/unit_tests/lua.cc
+++ b/tests/unit_tests/lua.cc
@@ -35,6 +35,8 @@
 #include <momemta/ParameterSet.h>
 #include <momemta/Path.h>
 
+#include <lua/LazyTable.h>
+#include <lua/ParameterSetParser.h>
 #include <lua/Path.h>
 #include <lua/Types.h>
 #include <lua/utils.h>
@@ -73,12 +75,12 @@ class LuaCallbackMock: public ILuaCallback {
 };
 
 // A small mock of LazyParameterSet to change visibility of the `freeze` function
-class LazyParameterSetMock: public LazyParameterSet {
-    using LazyParameterSet::LazyParameterSet;
+class LazyTableMock: public lua::LazyTable {
+    using lua::LazyTable::LazyTable;
 
     public:
         virtual void freeze() override {
-            LazyParameterSet::freeze();
+            lua::LazyTable::freeze();
         }
 };
 
@@ -286,7 +288,7 @@ TEST_CASE("lua parsing utilities", "[lua]") {
         REQUIRE(type == LUA_TTABLE);
 
         ParameterSet p;
-        p.parse(L.get(), -1);
+        ParameterSetParser::parse(p, L.get(), -1);
 
         REQUIRE(p.existsAs<int64_t>("integer"));
         REQUIRE(p.get<int64_t>("integer") == 1);
@@ -325,8 +327,8 @@ TEST_CASE("lua parsing utilities", "[lua]") {
         int type = lua_getglobal(L.get(), "test_table");
         REQUIRE(type == LUA_TTABLE);
 
-        LazyParameterSetMock p(L, "test_table");
-        p.parse(L.get(), -1);
+        LazyTableMock p(L, "test_table");
+        ParameterSetParser::parse(p, L.get(), -1);
 
         auto f = p;
         f.freeze();
@@ -382,7 +384,7 @@ TEST_CASE("lua parsing utilities", "[lua]") {
         lua_pop(L.get(), 1);
         REQUIRE(type == LUA_TNIL);
 
-        LazyParameterSetMock p(L, "test_table");
+        LazyTableMock p(L, "test_table");
 
         // Table must not exist
         type = lua_getglobal(L.get(), "test_table");


### PR DESCRIPTION
As discussed yesterday, it's really useful to the user to inject variables into the lua configuration, for example to use transfer function or not, or to switch between muons or electrons, or whatever.

This is done by adding a new optional argument to `ConfigurationReader` constructor. It's a `ParameterSet`, and each entry of this set will be injected as a global variable into the lua state. You can see an example in the TTbar example, where I inject the `USE_PERM` and `USE_TF` variables.

First commit is not directly related to this PR, but decouples `ParameterSet` and lua, moving `LazyParameterSet` to the `lua/` subfolder (and now named `lua::LazyTable` to reflect what it really is)

cc @BrieucF 