### PR TITLE
Add other integration algos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - `ConfigurationReader` constructor now accepts an optional second argument allowing the definition of variables accessible from the lua configuration. 
  - When an exception occurs while constructing a module, try to give useful information to help debugging.
  - Support for CMSSW environment. Python, boost and LHAPDF libraries from CMSSW are automatically used and running `make install` will automatically register MoMEMta as a new external tool. Please note that CMSSW does not ship with boost::log. As a consequence, logging is disabled when building inside such an environment.
+ - Support use of other integration algorithms implemented in Cuba (Suave, Divonne, Cuhre)
 
 ### Changed
  - The way to handle multiple solutions coming from blocks has changed. A module is no longer responsible for looping over the solutions itself, this role is delegated to the `Looper` module. As a consequence, most of the module were rewritten to handle this change. See this [pull request](https://github.com/MoMEMta/MoMEMta/pull/69) and [this one](https://github.com/MoMEMta/MoMEMta/pull/91) for a more technical description, and this [documentation entry](http://momemta.github.io/) for more details

--- a/include/momemta/MoMEMta.h
+++ b/include/momemta/MoMEMta.h
@@ -88,10 +88,14 @@ class MoMEMta {
         class integrands_output_error: public std::runtime_error {
             using std::runtime_error::runtime_error;
         };
+        class cuba_configuration_error: public std::runtime_error {
+            using std::runtime_error::runtime_error;
+        };
 
-        int integrand(const double* psPoints, const double* weights, double* results);
+        int integrand(const double* psPoints, double* results, const double* weights);
 
-        static int CUBAIntegrand(const int *nDim, const double* psPoint, const int *nComp, double *value, void *inputs, const int *nVec, const int *core, const double *weight);
+        static int CUBAIntegrand(const int *nDim, const double* psPoint, const int *nComp, double *value, void *inputs, const int *nVec, const int *core);
+        static int CUBAIntegrandWeighted(const int *nDim, const double* psPoint, const int *nComp, double *value, void *inputs, const int *nVec, const int *core, const double *weight);
         static void cuba_logging(const char*);
 
         PoolPtr m_pool;


### PR DESCRIPTION
Add Suave, Divonne and Cuhre as available in Cuba. To choose the algorithm, simply set the `algorithm` parameter in the Cuba global parameters in Lua (default to `vegas`).

The algos have lots of parameters that can be tweaked. I haven't tried to optimise them, so the default values are probably rubbish. Only experience will tell what is best (dedicace @BrieucF ). On the ttbar examples in MoMEMta, with these parameters Vegas converged always faster...

Divonne allows one to specify manually where the peaks are located. I've left it empty since for us it's almost impossible to know where the peaks are once the propagators have been removed. It might be possible in certain cases e.g. with transfer functions, so let's keep it in mind (not on the priority list for now)...