### PR TITLE
Fix transfer functions on energy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
  - Cuba forking mode was broken when building in release mode (with `-DCMAKE_RELEASE_TYPE=Release`).
  - SLHA card reader (matrix element parameter cards) retrieved from MadGraph was broken.
+ - Transfer functions on energy take as lower bound the mass of the given "reco" particle

--- a/modules/GaussianTransferFunctionOnEnergy.cc
+++ b/modules/GaussianTransferFunctionOnEnergy.cc
@@ -99,7 +99,7 @@ class GaussianTransferFunctionOnEnergy: public GaussianTransferFunctionOnEnergyB
             // Estimate the width over which to integrate using the width of the TF at E_rec ...
             const double sigma_E_rec = m_reco_input->E() * m_sigma;
 
-            double range_min = std::max(0., m_reco_input->E() - (m_sigma_range * sigma_E_rec));
+            double range_min = std::max(m_reco_input->M(), m_reco_input->E() - (m_sigma_range * sigma_E_rec));
             double range_max = m_reco_input->E() + (m_sigma_range * sigma_E_rec);
             double range = (range_max - range_min);
 


### PR DESCRIPTION
Fix "bug" discovered by @BrieucF : transfer functions on energy now take as lower bound on Egen the mass of the given "reco" particle (lower bound was zero before, leading to NaNs if the object's mass was too high).