### PR TITLE
Clear paths before creating the graph

### DIFF
--- a/core/src/Graph.cc
+++ b/core/src/Graph.cc
@@ -117,6 +117,9 @@ Graph build(const Pool::DescriptionMap& description, std::vector<ModulePtr>& mod
     }
 
     modules.clear();
+    for (auto& path: paths) {
+        path->modules.clear();
+    }
 
     // Create edges. One edge connect one module output to one module input
     for (const auto& vertex: vertices) {


### PR DESCRIPTION
Fix an issue where runtime was increasing each time a configuration reader was frozen. Modules inside each looper path were duplicated.