### PR TITLE
Further fix to TF energy

### DIFF
--- a/modules/BinnedTransferFunctionOnEnergy.cc
+++ b/modules/BinnedTransferFunctionOnEnergy.cc
@@ -155,7 +155,7 @@ class BinnedTransferFunctionOnEnergy: public BinnedTransferFunctionOnEnergyBase 
             const double delta = rec_E - gen_E;
 
             // To change the particle's energy without changing its direction and mass:
-            const double gen_pt = std::sqrt(SQ(gen_E) - SQ(rec_M)) / std::cosh(m_reco_input->Eta());
+            const double gen_pt = std::sqrt((gen_E - rec_M) * (gen_E + rec_M)) / std::cosh(m_reco_input->Eta());
             output->SetCoordinates(
                     gen_pt * std::cos(m_reco_input->Phi()),
                     gen_pt * std::sin(m_reco_input->Phi()),


### PR DESCRIPTION
It looks like the check introduced in #110 was not sufficient to prevent `gen_pt` to be `nan`. Rejecting `gen_E < rec_M` is not enough either, only rejecting SQ(gen_E) < SQ(rec_M) did the trick... Looks like a precision issue. I don't know whether @swertz is ok with this way to fix it or not so I open the PR for discussion. 