### PR TITLE
Fix configuration freezing when using a Looper

### DIFF
--- a/core/src/Graph.cc
+++ b/core/src/Graph.cc
@@ -64,7 +64,7 @@ bool checkInPath(Graph& g, vertex_t looper, vertex_t module) {
 
     // We know that the module is a Looper
     // grab its execution path from its configuration
-    auto looper_path = g[looper].configuration_module.parameters->get<Path>("path");
+    const auto& looper_path = g[looper].configuration_module.parameters->get<Path>("path");
     const auto& path_modules = looper_path.modules();
 
     const auto& target = g[module];
@@ -265,7 +265,9 @@ Graph build(const Pool::DescriptionMap& description, std::vector<ModulePtr>& mod
     }
 
     for (auto& path: paths) {
+        // This path can't change anymore, so it's safe to freeze it
         path->resolved = true;
+
         for (const auto& name: path->elements) {
             auto it = std::find_if(path->modules.begin(), path->modules.end(), [&name](const ModulePtr& module) { return module->name() == name; });
             if (it == path->modules.end()) {

--- a/core/src/MoMEMta.cc
+++ b/core/src/MoMEMta.cc
@@ -24,6 +24,7 @@
 
 #include <momemta/Configuration.h>
 #include <momemta/Logging.h>
+#include <momemta/Path.h>
 #include <momemta/ParameterSet.h>
 #include <momemta/Utils.h>
 #include <momemta/Unused.h>
@@ -59,7 +60,6 @@ MoMEMta::MoMEMta(const Configuration& configuration) {
         m_pool->current_module(module);
         try {
             m_modules.push_back(ModuleFactory::get().create(module.type, m_pool, *module.parameters));
-            m_modules.back()->configure();
         } catch (...) {
             LOG(fatal) << "Exception while trying to create module " << module.type << "::" << module.name
                        << ". See message above for a (possible) more detailed description of the error.";
@@ -104,6 +104,16 @@ MoMEMta::MoMEMta(const Configuration& configuration) {
 
     // Freeze the pool after removing unneeded modules
     m_pool->freeze();
+
+    for (const auto& module: m_modules) {
+        module->configure();
+    }
+
+    // Reset configuration path to the configuration state
+    for (auto& path: configuration.getPaths()) {
+        path->modules.clear();
+        path->resolved = false;
+    }
 
     // Register logging function
     cubalogging(MoMEMta::cuba_logging);

--- a/core/src/Path.cc
+++ b/core/src/Path.cc
@@ -20,12 +20,27 @@
 
 #include <momemta/Module.h>
 
-Path::Path(PathElementsPtr elements) { this->elements = elements; }
-
-bool Path::resolved() const {
-    return elements && elements->resolved;
+Path::Path(PathElementsPtr elements) {
+    elements_ = elements;
 }
 
 const std::vector<ModulePtr>& Path::modules() const {
-    return elements->modules;
+    if (!frozen) {
+        if (! elements_ || !elements_->resolved)
+            throw std::runtime_error("You can access modules inside a path only if the elements are resolved. Maybe you forgot to call `freeze`?");
+
+        return elements_->modules;
+    }
+
+    return modules_;
+}
+
+void Path::freeze() {
+
+    if (frozen)
+        return;
+
+    frozen = true;
+    modules_ = elements_->modules;
+    elements_ = nullptr;
 }

--- a/core/src/lua/Path.cc
+++ b/core/src/lua/Path.cc
@@ -35,7 +35,7 @@ void lua::path_register(lua_State* L, void* ptr) {
         {"__gc", path_free},
         {nullptr, nullptr}
     };
-    luaL_setfuncs(L, functions, 0); 
+    luaL_setfuncs(L, functions, 0);
 
     lua_pop(L, 1);
 
@@ -66,7 +66,7 @@ int lua::path_new(lua_State* L) {
 
     (*pPath)->elements = module_names;
 
-    
+
     void* cfg_ptr = lua_touserdata(L, lua_upvalueindex(1));
     ILuaCallback* callback = static_cast<ILuaCallback*>(cfg_ptr);
     callback->onNewPath(*pPath);
@@ -75,7 +75,7 @@ int lua::path_new(lua_State* L) {
 }
 
 int lua::path_free(lua_State* L) {
-    delete *static_cast<Path**>(luaL_checkudata(L, 1, LUA_PATH_TYPE_NAME));
+    delete *static_cast<PathElementsPtr*>(luaL_checkudata(L, 1, LUA_PATH_TYPE_NAME));
 
     return 0;
 }

--- a/include/momemta/Path.h
+++ b/include/momemta/Path.h
@@ -81,17 +81,15 @@ class Path {
         const std::vector<std::shared_ptr<Module>>& modules() const;
 
         /**
-         * \brief Test if this instance was already resolved
+         * \brief Freeze this Path.
          *
-         * A Path must be resolved first before one can access the list of modules. This is done
-         * by the Graph system after all modules have been created.
+         * This ensure that any later modification to the configuration won't affect this path
          *
-         * The return values of Path::modules() is only valid if resolved() returns `true`
-         *
-         * \return True if this Path has already been resolved, false otherwise
          */
-        bool resolved() const;
+        void freeze();
 
     private:
-        PathElementsPtr elements = nullptr;
+        PathElementsPtr elements_ = nullptr;
+        bool frozen = false;
+        std::vector<std::shared_ptr<Module>> modules_;
 };

--- a/modules/Looper.cc
+++ b/modules/Looper.cc
@@ -113,10 +113,15 @@ class Looper: public Module {
     public:
 
         Looper(PoolPtr pool, const ParameterSet& parameters): Module(pool, parameters.getModuleName()) {
-            solutions = pool->get<SolutionCollection>(parameters.get<InputTag>("solutions")); 
+            solutions = pool->get<SolutionCollection>(parameters.get<InputTag>("solutions"));
 
             path = parameters.get<Path>("path");
         };
+
+        virtual void configure() override {
+            path.freeze();
+            CALL(configure);
+        }
 
         virtual void beginIntegration() override {
             CALL(beginIntegration);


### PR DESCRIPTION
The looper path was not saving a copy of the modules it needs to run,
but used directly the list coming from the configuration file. As soon
as it's modified, after a freeze for example, the list is no longer
valid.

The looper now freeze the path before using it, enforcing a copy of the
list of modules. This is done in `configure`, which is now called
**after** the Graph evaluation, instead of before as previously.

@BrieucF: Can you check that this solves your crash?
