### PR TITLE
Rename block inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - `declare_input` lua function, used to declare a new input.
  - `append` and `copy_and_append` lua functions are now built-in MoMEMta.
  - Two new lua functions, `add_reco_permutations` and `add_gen_permutations` are available to easily insert a permutator module permutating between the function arguments. 
+ - Secondary block B
+ - `LinearCombinator` templated module allowing to compute combinations (ie sums, subtractions, ...) of LorentzVectors, numbers, ...
 
 ### Changed
  - The way to handle multiple solutions coming from blocks has changed. A module is no longer responsible for looping over the solutions itself, this role is delegated to the `Looper` module. As a consequence, most of the module were rewritten to handle this change. See this [pull request](https://github.com/MoMEMta/MoMEMta/pull/69) and [this one](https://github.com/MoMEMta/MoMEMta/pull/91) for a more technical description, and this [documentation entry](http://momemta.github.io/) for more details
@@ -34,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - We no longer use boost-log for logging, but our own implementation heavily inspired by [spdlog](https://github.com/gabime/spdlog). As a consequence, boost-log is no longer required to build MoMEMta.
  - Boost is no longer a dependency when **using** MoMEMta (but it's still a build dependency)
  - `MoMEMta::computeWeights` now expects a vector of `Particle` and no longer a vector of `LorentzVector`. A `Particle` has a name, a `LorentzVector` and a type. As a result, configuration files must now declare which inputs are expected.
+ - The way the inputs are passed to the blocks is changed (the particles entering the change of variables are set explicitly, the others are put into the `branches` vector of input tags)
 
 ### Fixed
  - Cuba forking mode was broken when building in release mode (with `-DCMAKE_RELEASE_TYPE=Release`).

--- a/examples/WW_fullyleptonic.lua
+++ b/examples/WW_fullyleptonic.lua
@@ -49,7 +49,8 @@ end
 inputs = {electron.gen_p4, muon.gen_p4}
 
 BlockF.blockf = {
-    inputs = inputs,
+    p3 = inputs[1],
+    p4 = inputs[2],
 
     s13 = 'flatter_s13::s',
     s24 = 'flatter_s24::s',

--- a/examples/tt_fullyleptonic.lua
+++ b/examples/tt_fullyleptonic.lua
@@ -111,7 +111,10 @@ StandardPhaseSpace.phaseSpaceOut = {
 -- Declare module before the permutator to test read-access in the pool
 -- for non-existant values.
 BlockD.blockd = {
-    inputs = inputs,
+    p3 = inputs[1],
+    p4 = inputs[2],
+    p5 = inputs[3],
+    p6 = inputs[4],
 
     pT_is_met = true,
 

--- a/examples/tt_fullyleptonic_NWA.lua
+++ b/examples/tt_fullyleptonic_NWA.lua
@@ -78,7 +78,10 @@ inputs = {
 }
 
 BlockD.blockd = {
-    inputs = inputs,
+    p3 = inputs[1],
+    p4 = inputs[2],
+    p5 = inputs[3],
+    p6 = inputs[4],
 
     s13 = 'nwa_s13::s',
     s134 = 'nwa_s134::s',

--- a/modules/BlockA.cc
+++ b/modules/BlockA.cc
@@ -88,7 +88,7 @@ class BlockA: public Module {
             auto branches_tags = parameters.get<std::vector<InputTag>>("branches");
             for (auto& t: branches_tags)
                 m_branches.push_back(get<LorentzVector>(t));
-            if (!m_branches.size()) {
+            if (m_branches.empty()) {
                 auto exception = std::invalid_argument("BlockA is not valid without at least a third particle in the event.");
                 LOG(fatal) << exception.what();
                 throw exception;

--- a/modules/BlockA.cc
+++ b/modules/BlockA.cc
@@ -25,6 +25,8 @@
 #include <momemta/Utils.h>
 #include <momemta/Math.h>
 
+#include <stdexcept>
+
 /** \brief Final (main) Block A, describing \f$q_1 q_2 \to p_1 + p_2 + X\f$
  *
  * \f$q_1\f$ and \f$q_2\f$ are Bjorken fractions, \f$p_1\f$ and \f$p_2\f$ are the 4-momenta of the visible
@@ -57,7 +59,8 @@
  *
  *   | Name | Type | %Description |
  *   |------|------|--------------|
- *   | `inputs` | vector(LorentzVector) | LorentzVector of all the experimentally reconstructed particles. Only the first two particles are used explicitly by the block, but there can be other visible objects in the event, taken into account when computing \f$\vec{p}_{T}^{branches}\f$. |
+ *   | `p1` <br/> `p2` | LorentzVector | 4-vectors of the two particles for which the energy will be fixed using the above described method. Their angles and masses will be kept. | 
+ *   | `branches` | vector(LorentzVector) | LorentzVector of all the other particles in the event, taken into account when computing \f$\vec{p}_{T}^{branches}\f$ and check if the solutions are physical. At least one other particle must be present for this block to be valid. |
  *
  * ### Outputs
  *
@@ -79,31 +82,36 @@ class BlockA: public Module {
 
             sqrt_s = parameters.globalParameters().get<double>("energy");
             
-            auto particle_tags = parameters.get<std::vector<InputTag>>("inputs");
-            for (auto& t: particle_tags)
-                m_particles.push_back(get<LorentzVector>(t));
+            p1 = get<LorentzVector>(parameters.get<InputTag>("p1"));
+            p2 = get<LorentzVector>(parameters.get<InputTag>("p2"));
+            
+            auto branches_tags = parameters.get<std::vector<InputTag>>("branches");
+            for (auto& t: branches_tags)
+                m_branches.push_back(get<LorentzVector>(t));
+            if (!m_branches.size()) {
+                auto exception = std::invalid_argument("BlockA is not valid without at least a third particle in the event.");
+                LOG(fatal) << exception.what();
+                throw exception;
+            }
         };
  
         virtual Status work() override {
 
             solutions->clear();
 
-            const LorentzVector& p1 = *m_particles[0];
-            const LorentzVector& p2 = *m_particles[1];
-
             LorentzVector pb;
-            for (size_t i = 2; i < m_particles.size(); i++) {
-                pb += *m_particles[i];
+            for (size_t i = 0; i < m_branches.size(); i++) {
+                pb += *m_branches[i];
             }
 
             double pbx = pb.Px();
             double pby = pb.Py();
-            const double theta1 = p1.Theta();
-            const double phi1 = p1.Phi();
-            const double theta2 = p2.Theta();
-            const double phi2 = p2.Phi();
-            const double m1 = p1.M();
-            const double m2 = p2.M();
+            const double theta1 = p1->Theta();
+            const double phi1 = p1->Phi();
+            const double theta2 = p2->Theta();
+            const double phi2 = p2->Phi();
+            const double m1 = p1->M();
+            const double m2 = p2->M();
 
             // pT = p1+p2+pb = 0. Equivalent to the following system:
             // p1x+p2x = -pbx
@@ -168,7 +176,8 @@ class BlockA: public Module {
         double sqrt_s;
 
         // Inputs
-        std::vector<Value<LorentzVector>> m_particles;
+        Value<LorentzVector> p1, p2;
+        std::vector<Value<LorentzVector>> m_branches;
         // Outputs
         std::shared_ptr<SolutionCollection> solutions = produce<SolutionCollection>("solutions");
 };

--- a/modules/BlockB.cc
+++ b/modules/BlockB.cc
@@ -94,9 +94,11 @@ class BlockB: public Module {
 
             p2 = get<LorentzVector>(parameters.get<InputTag>("p2"));
             
-            auto branches_tags = parameters.get<std::vector<InputTag>>("branches");
-            for (auto& t: branches_tags)
-                m_branches.push_back(get<LorentzVector>(t));
+            if (parameters.exists("branches")) {
+                auto branches_tags = parameters.get<std::vector<InputTag>>("branches");
+                for (auto& t: branches_tags)
+                    m_branches.push_back(get<LorentzVector>(t));
+            }
 
             // If the met input is specified, get it, otherwise retrieve default
             // one ("met::p4")
@@ -139,7 +141,7 @@ class BlockB: public Module {
             // From eq.(1) p1z = B*E1 + A
             // From eq.(4) + eq.(1) (1 - B^2) E1^2 - 2 A B E1 + C - A^2 = 0
 
-            const double A = - (*s12 - p2-> - 2 * (pT.Px() * p2->Px() + pT.Py() * p2->Py())) / (2 * p2->Pz());
+            const double A = - (*s12 - p22 - 2 * (pT.Px() * p2->Px() + pT.Py() * p2->Py())) / (2 * p2->Pz());
             const double B = p2->E() / p2->Pz();
             const double C = - SQ(pT.Px()) - SQ(pT.Py());
 

--- a/modules/BlockB.cc
+++ b/modules/BlockB.cc
@@ -64,8 +64,9 @@
  *
  *   | Name | Type | %Description |
  *   |------|------|--------------|
- *   | `s12` | double | Invariant mass of the particle decaying into the missing particle (\f$p_1\f$) and the visible particle, \f$p_2\f$. Typically coming from a BreitWignerGenerator module.
- *   | `inputs` | vector(LorentzVector) | LorentzVector of all the experimentally reconstructed particles. In this Block there is only one visible particle used explicitly, \f$p_2\f$, but there can be other visible objects in the the event, taken into account when computing \f$\vec{p}_{T}^{tot}\f$.
+ *   | `s12` | double | Squared invariant mass of the particle decaying into the missing particle (\f$p_1\f$) and the visible particle, \f$p_2\f$. Typically coming from a BreitWignerGenerator module.
+ *   | `p2` | LorentzVector | LorentzVector of the particle \f$p_2\f$, as described above. |
+ *   | `branches` | vector(LorentzVector) | LorentzVector of all the other particles in the event, taken into account when computing \f$\vec{p}_{T}^{tot}\f$ and checking if the solutions are physical. |
  *   | `met` | LorentzVector, default `met::p4` | LorentzVector of the MET |
  *
  * ### Outputs
@@ -91,9 +92,11 @@ class BlockB: public Module {
 
             s12 = get<double>(parameters.get<InputTag>("s12"));
 
-            auto particle_tags = parameters.get<std::vector<InputTag>>("inputs");
-            for (auto& t: particle_tags)
-                m_particles.push_back(get<LorentzVector>(t));
+            p2 = get<LorentzVector>(parameters.get<InputTag>("p2"));
+            
+            auto branches_tags = parameters.get<std::vector<InputTag>>("branches");
+            for (auto& t: branches_tags)
+                m_branches.push_back(get<LorentzVector>(t));
 
             // If the met input is specified, get it, otherwise retrieve default
             // one ("met::p4")
@@ -121,25 +124,23 @@ class BlockB: public Module {
             if (*s12 > SQ(sqrt_s))
                 return Status::NEXT;
 
-            const LorentzVector& p2 = *m_particles[0];
-
             LorentzVector pT;
             if (pT_is_met) {
                 pT = - *m_met;
             } else {
-                pT = p2;
-                for (size_t i = 1; i < m_particles.size(); i++) {
-                    pT += *m_particles[i];
+                pT = *p2;
+                for (size_t i = 0; i < m_branches.size(); i++) {
+                    pT += *m_branches[i];
                 }
             }
 
-            const double p22 = p2.M2();
+            const double p22 = p2->M2();
 
             // From eq.(1) p1z = B*E1 + A
             // From eq.(4) + eq.(1) (1 - B^2) E1^2 - 2 A B E1 + C - A^2 = 0
 
-            const double A = - (*s12 - p22 - 2 * (pT.Px() * p2.Px() + pT.Py() * p2.Py())) / (2 * p2.Pz());
-            const double B = p2.E() / p2.Pz();
+            const double A = - (*s12 - p2-> - 2 * (pT.Px() * p2->Px() + pT.Py() * p2->Py())) / (2 * p2->Pz());
+            const double B = p2->E() / p2->Pz();
             const double C = - SQ(pT.Px()) - SQ(pT.Py());
 
             // Solve quadratic a*E1^2 + b*E1 + c = 0
@@ -162,16 +163,15 @@ class BlockB: public Module {
                 LorentzVector p1(-pT.Px(), -pT.Py(), A + B*e1, e1);
 
                 // Check if solutions are physical
-                LorentzVector tot = p1 + p2;
-                for (size_t i = 1; i < m_particles.size(); i++) {
-                    tot += *m_particles[i];
-                }
+                LorentzVector tot = p1 + *p2;
+                for (size_t i = 0; i < m_branches.size(); i++)
+                    tot += *m_branches[i];
                 double q1Pz = std::abs(tot.Pz() + tot.E()) / 2.;
                 double q2Pz = std::abs(tot.Pz() - tot.E()) / 2.;
                 if(q1Pz > sqrt_s/2 || q2Pz > sqrt_s/2)
                     continue;
 
-                const double inv_jacobian = SQ(sqrt_s) * std::abs(p2.Pz() * e1 - p2.E() * p1.Pz());
+                const double inv_jacobian = SQ(sqrt_s) * std::abs(p2->Pz() * e1 - p2->E() * p1.Pz());
 
                 Solution s { {p1}, M_PI/inv_jacobian, true };
                 solutions->push_back(s);
@@ -186,7 +186,8 @@ class BlockB: public Module {
 
         // Inputs
         Value<double> s12;
-        std::vector<Value<LorentzVector>> m_particles;
+        Value<LorentzVector> p2;
+        std::vector<Value<LorentzVector>> m_branches;
         Value<LorentzVector> m_met;
 
         // Outputs

--- a/modules/BlockD.cc
+++ b/modules/BlockD.cc
@@ -100,9 +100,11 @@ class BlockD: public Module {
             m_particles.push_back(get<LorentzVector>(parameters.get<InputTag>("p5")));
             m_particles.push_back(get<LorentzVector>(parameters.get<InputTag>("p6")));
             
-            auto branches_tags = parameters.get<std::vector<InputTag>>("branches");
-            for (auto& t: branches_tags)
-                m_branches.push_back(get<LorentzVector>(t));
+            if (parameters.exists("branches")) {
+                auto branches_tags = parameters.get<std::vector<InputTag>>("branches");
+                for (auto& t: branches_tags)
+                    m_branches.push_back(get<LorentzVector>(t));
+            }
 
             // If the met input is specified, get it, otherwise retrieve default
             // one ("met::p4")

--- a/modules/BlockF.cc
+++ b/modules/BlockF.cc
@@ -103,9 +103,11 @@ class BlockF: public Module {
             p3 = get<LorentzVector>(parameters.get<InputTag>("p3"));
             p4 = get<LorentzVector>(parameters.get<InputTag>("p4"));
 
-            auto branches_tags = parameters.get<std::vector<InputTag>>("branches");
-            for (auto& t: branches_tags)
-                m_branches.push_back(get<LorentzVector>(t));
+            if (parameters.exists("branches")) {
+                auto branches_tags = parameters.get<std::vector<InputTag>>("branches");
+                for (auto& t: branches_tags)
+                    m_branches.push_back(get<LorentzVector>(t));
+            }
         };
 
         virtual Status work() override {

--- a/modules/BlockG.cc
+++ b/modules/BlockG.cc
@@ -86,14 +86,16 @@ class BlockG: public Module {
             s12 = get<double>(parameters.get<InputTag>("s12"));
             s34 = get<double>(parameters.get<InputTag>("s34"));
 
-            m_particles.push_back(parameters.get<InputTag>("p1"));
-            m_particles.push_back(parameters.get<InputTag>("p2"));
-            m_particles.push_back(parameters.get<InputTag>("p3"));
-            m_particles.push_back(parameters.get<InputTag>("p4"));
+            m_particles.push_back(get<LorentzVector>(parameters.get<InputTag>("p1")));
+            m_particles.push_back(get<LorentzVector>(parameters.get<InputTag>("p2")));
+            m_particles.push_back(get<LorentzVector>(parameters.get<InputTag>("p3")));
+            m_particles.push_back(get<LorentzVector>(parameters.get<InputTag>("p4")));
 
-            auto branches_tags = parameters.get<std::vector<InputTag>>("branches");
-            for (auto& t: branches_tags)
-                m_branches.push_back(get<LorentzVector>(t));
+            if (parameters.exists("branches")) {
+                auto branches_tags = parameters.get<std::vector<InputTag>>("branches");
+                for (auto& t: branches_tags)
+                    m_branches.push_back(get<LorentzVector>(t));
+            }
         };
  
         virtual Status work() override {

--- a/modules/BlockG.cc
+++ b/modules/BlockG.cc
@@ -60,7 +60,8 @@
  *   | Name | Type | %Description |
  *   |------|------|--------------|
  *   | `s12` <br/> `s34` | double | Squared invariant masses of the propagators. Typically coming from a BreitWignerGenerator or NarrowWidthApproximation module.
- *   | `inputs` | vector(LorentzVector) | LorentzVector of all the experimentally reconstructed particles. Only the first four particles are used explicitly by the block, but there can be other objects in the event, taken into account when computing \f$\vec{p}_{T}^{b}\f$. |
+ *   | `p1` ... `p4` | LorentzVector | LorentzVectors of the four particles in the event. The masses and angles of these particles will be used as input, and their energies modified according to the above method to reconstruct the event. |
+ *   | `branches` | vector(LorentzVector) | LorentzVectors of all the other particles in the event, taken into account when computing \f$\vec{p}_{T}^{b}\f$. |
  *
  * ### Outputs
  *
@@ -85,9 +86,14 @@ class BlockG: public Module {
             s12 = get<double>(parameters.get<InputTag>("s12"));
             s34 = get<double>(parameters.get<InputTag>("s34"));
 
-            auto particle_tags = parameters.get<std::vector<InputTag>>("inputs");
-            for (auto& t: particle_tags)
-                m_particles.push_back(get<LorentzVector>(t));
+            m_particles.push_back(parameters.get<InputTag>("p1"));
+            m_particles.push_back(parameters.get<InputTag>("p2"));
+            m_particles.push_back(parameters.get<InputTag>("p3"));
+            m_particles.push_back(parameters.get<InputTag>("p4"));
+
+            auto branches_tags = parameters.get<std::vector<InputTag>>("branches");
+            for (auto& t: branches_tags)
+                m_branches.push_back(get<LorentzVector>(t));
         };
  
         virtual Status work() override {
@@ -103,8 +109,8 @@ class BlockG: public Module {
             const LorentzVector& p4 = *m_particles[3];
 
             LorentzVector pb;
-            for (size_t i = 4; i < m_particles.size(); i++) {
-                pb += *m_particles[i];
+            for (size_t i = 0; i < m_branches.size(); i++) {
+                pb += *m_branches[i];
             }
 
             const double pbx = pb.Px();
@@ -197,6 +203,7 @@ class BlockG: public Module {
         double sqrt_s;
 
         // Inputs
+        std::vector<Value<LorentzVector>> m_branches;
         std::vector<Value<LorentzVector>> m_particles;
         Value<double> s12, s34;
         // Outputs

--- a/modules/SecondaryBlockB.cc
+++ b/modules/SecondaryBlockB.cc
@@ -59,9 +59,8 @@
  *   |------|------|--------------|
  *   | `s12` | double | Squared invariant mass of the propagator (GeV\f$^2\f$). |
  *   | `s123` | double | Squared invariant mass of the propagator (GeV\f$^2\f$). |
- *   | `p1` | LorentzVector | Temporary LorentzVector of the missing particle. It will be used only to retrieve the particle phi angle and mass.|
- *   | `p2` | LorentzVector | Parton level LorentzVector of a decay product for which we already know everything (see above description).|
- *   | `p3` | LorentzVector | Parton level LorentzVector of a decay product for which we already know everything (see above description).|
+ *   | `p1` | LorentzVector | LorentzVector of the missing particle we want to reconstruct. It will be used only to retrieve the particle phi angle and mass.|
+ *   | `p2` <br/> `p3` | LorentzVector | LorentzVectors of the two decay products used to reconstruct fully `p1` (see above description).|
  *
  * ### Outputs
  *

--- a/modules/SecondaryBlockB.cc
+++ b/modules/SecondaryBlockB.cc
@@ -81,12 +81,10 @@ class SecondaryBlockB: public Module {
             sqrt_s(parameters.globalParameters().get<double>("energy")) {
                 s12 = get<double>(parameters.get<InputTag>("s12"));
                 s123 = get<double>(parameters.get<InputTag>("s123"));
-                InputTag p1_tag = parameters.get<InputTag>("p1");
-                m_p1 = get<LorentzVector>(p1_tag);
-                InputTag p2_tag = parameters.get<InputTag>("p2");
-                m_p2 = get<LorentzVector>(p2_tag);
-                InputTag p3_tag = parameters.get<InputTag>("p3");
-                m_p3 = get<LorentzVector>(p3_tag);
+                
+                m_p1 = get<LorentzVector>(parameters.get<InputTag>("p1"));
+                m_p2 = get<LorentzVector>(parameters.get<InputTag>("p2"));
+                m_p3 = get<LorentzVector>(parameters.get<InputTag>("p3"));
             };
 
         virtual Status work() override {

--- a/modules/SecondaryBlockCD.cc
+++ b/modules/SecondaryBlockCD.cc
@@ -81,7 +81,7 @@ class SecondaryBlockCD: public Module {
 
         virtual Status work() override {
 
-            gen_p1->clear();
+            solutions->clear();
 
             // Don't spend time on unphysical part of phase-space
             if (*s12 > SQ(sqrt_s) || *s12 < p2->M2() || *s12 < p1->M2())

--- a/tests/bindings/python/configuration.lua
+++ b/tests/bindings/python/configuration.lua
@@ -81,7 +81,11 @@ inputs = {
 -- Declare module before the permutator to test read-access in the pool
 -- for non-existant values.
 BlockD.blockd = {
-    inputs = inputs,
+    p3 = inputs[1],
+    p4 = inputs[2],
+    p5 = inputs[3],
+    p6 = inputs[4],
+    
     pT_is_met = true,
     s13 = 'flatter_s13::s',
     s134 = 'flatter_s134::s',

--- a/tests/crossSections/blockA_WW_dilep.lua
+++ b/tests/crossSections/blockA_WW_dilep.lua
@@ -103,8 +103,7 @@ StandardPhaseSpace.phaseSpaceOut = {
 BlockA.blocka = {
     p1 = inputs[1],
     p2 = inputs[2],
-    p3 = inputs[3],
-    p4 = inputs[4],
+    branches = { inputs[3], inputs[4] },
 }
 
 -- Loop

--- a/tests/crossSections/blockA_WW_dilep.lua
+++ b/tests/crossSections/blockA_WW_dilep.lua
@@ -101,7 +101,10 @@ StandardPhaseSpace.phaseSpaceOut = {
 }
 
 BlockA.blocka = {
-    inputs = inputs,
+    p1 = inputs[1],
+    p2 = inputs[2],
+    p3 = inputs[3],
+    p4 = inputs[4],
 }
 
 -- Loop

--- a/tests/crossSections/blockB_WW_dilep.lua
+++ b/tests/crossSections/blockB_WW_dilep.lua
@@ -85,7 +85,8 @@ StandardPhaseSpace.phaseSpaceOut = {
 
 BlockB.blockb = {
     s12 = 'flatter_w::s',
-    inputs = inputs,
+    p2 = inputs[1],
+    branches = { inputs[2], inputs[3] }
 }
 
 -- Loop

--- a/tests/crossSections/blockB_secondaryBlockCD_WW_dilep.lua
+++ b/tests/crossSections/blockB_secondaryBlockCD_WW_dilep.lua
@@ -85,8 +85,8 @@ StandardPhaseSpace.phaseSpaceOut = {
 
 SecondaryBlockCD.secBlockCD = {
     s12 = 'flatter_w1::s',
-    gen_p2 = inputs[1],
-    reco_p1 = inputs[2]
+    p2 = inputs[1],
+    p1 = inputs[2]
 }
 
 -- Loop for secondary
@@ -98,7 +98,8 @@ Looper.looperCD = {
 
     BlockB.blockb = {
         s12 = 'flatter_w2::s',
-        inputs = { inputs[3], inputs[1], 'looperCD::particles/1' },
+        p2 = inputs[3],
+        branches = { inputs[1], 'looperCD::particles/1' },
     }
 
     -- Loop for main block

--- a/tests/crossSections/blockB_secondaryBlockCD_WW_dilep.lua
+++ b/tests/crossSections/blockB_secondaryBlockCD_WW_dilep.lua
@@ -92,7 +92,7 @@ SecondaryBlockCD.secBlockCD = {
 -- Loop for secondary
 
 Looper.looperCD = {
-    solutions = 'secBlockCD::gen_p1',
+    solutions = 'secBlockCD::solutions',
     path = Path('blockb', 'looperB')
 }
 

--- a/tests/crossSections/blockD_ttx_dilep.lua
+++ b/tests/crossSections/blockD_ttx_dilep.lua
@@ -120,7 +120,10 @@ StandardPhaseSpace.phaseSpaceOut = {
 }
 
 BlockD.blockd = {
-    inputs = inputs,
+    p3 = inputs[1],
+    p4 = inputs[2],
+    p5 = inputs[3],
+    p6 = inputs[4],
 
     s13 = 'flatter_s13::s',
     s134 = 'flatter_s134::s',

--- a/tests/crossSections/blockF_WW_dilep.lua
+++ b/tests/crossSections/blockF_WW_dilep.lua
@@ -72,7 +72,8 @@ StandardPhaseSpace.phaseSpaceOut = {
 }
 
 BlockF.blockf = {
-    inputs = inputs,
+    p3 = inputs[1],
+    p4 = inputs[2],
 
     s13 = 'flatter_s13::s',
     s24 = 'flatter_s24::s',

--- a/tests/crossSections/blockG_WW_dilep.lua
+++ b/tests/crossSections/blockG_WW_dilep.lua
@@ -76,7 +76,10 @@ BreitWignerGenerator.flatter_w2 = {
 }
 
 BlockG.blockg = {
-    inputs = inputs,
+    p1 = inputs[1],
+    p2 = inputs[2],
+    p3 = inputs[3],
+    p4 = inputs[4],
 
     s12 = 'flatter_w1::s',
     s34 = 'flatter_w2::s',

--- a/tests/phaseSpaceVolume/blockA.lua
+++ b/tests/phaseSpaceVolume/blockA.lua
@@ -67,7 +67,9 @@ StandardPhaseSpace.phaseSpaceOut = {
 }
 
 BlockA.blocka = {
-    inputs = inputs,
+    p1 = inputs[1],
+    p2 = inputs[2],
+    branches = { inputs[3] },
 }
 
 -- Loop

--- a/tests/phaseSpaceVolume/blockA_secondaryBlockCD.lua
+++ b/tests/phaseSpaceVolume/blockA_secondaryBlockCD.lua
@@ -87,19 +87,21 @@ BreitWignerGenerator.flatter = {
 
 SecondaryBlockCD.secBlockCD = {
     s12 = 'flatter::s',
-    gen_p2 = inputs[1],
-    reco_p1 = inputs[2],
+    p2 = inputs[1],
+    p1 = inputs[2],
 }
 
 Looper.looperCD = {
-    solutions = 'secBlockCD::gen_p1',
+    solutions = 'secBlockCD::solutions',
     path = Path('blocka', 'looperA')
 }
 
 -- Loop for secondary block
 
     BlockA.blocka = {
-        inputs = { inputs[3], inputs[4], inputs[1], 'looperCD::particles/1' }
+        p1 = inputs[3],
+        p2 = inputs[4],
+        branches = { inputs[1], 'looperCD::particles/1' }
     }
 
     Looper.looperA = {

--- a/tests/phaseSpaceVolume/blockB.lua
+++ b/tests/phaseSpaceVolume/blockB.lua
@@ -70,7 +70,8 @@ StandardPhaseSpace.phaseSpaceOut = {
 }
 
 BlockB.blockb = {
-    inputs = inputs,
+    p2 = inputs[1],
+    branches = { inputs[2] },
     s12 = 'flatter::s',
 }
 

--- a/tests/phaseSpaceVolume/blockD.lua
+++ b/tests/phaseSpaceVolume/blockD.lua
@@ -126,7 +126,10 @@ StandardPhaseSpace.phaseSpaceOut = {
 }
 
 BlockD.blockd = {
-    inputs = inputs,
+    p3 = inputs[1],
+    p4 = inputs[2],
+    p5 = inputs[3],
+    p6 = inputs[4],
 
     s13 = 'flatter_s13::s',
     s134 = 'flatter_s134::s',

--- a/tests/phaseSpaceVolume/blockF.lua
+++ b/tests/phaseSpaceVolume/blockF.lua
@@ -76,7 +76,8 @@ StandardPhaseSpace.phaseSpaceOut = {
 }
 
 BlockF.blockf = {
-    inputs = inputs,
+    p3 = inputs[1],
+    p4 = inputs[2],
 
     s13 = 'flatter_s13::s',
     s24 = 'flatter_s24::s',

--- a/tests/phaseSpaceVolume/blockG.lua
+++ b/tests/phaseSpaceVolume/blockG.lua
@@ -80,7 +80,10 @@ BreitWignerGenerator.flatter_s34 = {
 }
 
 BlockG.blockg = {
-    inputs = inputs,
+    p1 = inputs[1],
+    p2 = inputs[2],
+    p3 = inputs[3],
+    p4 = inputs[4],
 
     s12 = 'flatter_s12::s',
     s34 = 'flatter_s34::s',

--- a/tests/unit_tests/modules.cc
+++ b/tests/unit_tests/modules.cc
@@ -200,13 +200,10 @@ TEST_CASE("Modules", "[modules]") {
         *s25 = s_13_25;
         *s256 = s_134_256;
 
-        std::vector<InputTag> inputs { 
-                { "input", "particles", 0 },
-                { "input", "particles", 1 },
-                { "input", "particles", 2 },
-                { "input", "particles", 3 }
-            };
-        parameters->createMock("inputs", inputs);
+        parameters->set("p3", InputTag("input", "particles", 0));
+        parameters->set("p4", InputTag("input", "particles", 1));
+        parameters->set("p5", InputTag("input", "particles", 2));
+        parameters->set("p6", InputTag("input", "particles", 3));
 
         Value<SolutionCollection> solutions = pool->get<SolutionCollection>({"BlockD", "solutions"});
 


### PR DESCRIPTION
As we discussed: the inputs for the blocks are now names explicitly, and the (optional) further particles in the event (needed to balance the total transverse momentum, and check if solutions are physical) are put into the `branches` vector of input tags.