### PR TITLE
Block F: support for massive invisibles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - `MoMEMta::computeWeights` now expects a vector of `Particle` and no longer a vector of `LorentzVector`. A `Particle` has a name, a `LorentzVector` and a type. As a result, configuration files must now declare which inputs are expected.
  - The way the inputs are passed to the blocks is changed (the particles entering the change of variables are set explicitly, the others are put into the `branches` vector of input tags)
  - Built-in lua version is now v5.3.4
+ - Block F supports massive invisible particles
 
 ### Fixed
  - Cuba forking mode was broken when building in release mode (with `-DCMAKE_RELEASE_TYPE=Release`).

--- a/modules/BlockE.cc
+++ b/modules/BlockE.cc
@@ -197,9 +197,9 @@ class BlockE: public Module {
              * yielding a quadratic equation in E2 only.
              */
 
-            const double fac = - 2 * (B1x * pbx - B1z * ptotz - pby);
-            const double a = 2 * (A1x * pbx - A1z * ptotz - Etot) / fac;
-            const double b = (SQ(Etot) + pow(C1x + pbx, 2) + pow(C1z - ptotz, 2) + sq_m2 - SQ(C1x) - SQ(pby) - SQ(C1z) - sq_m1) / fac;
+            const double fac = 2 * (A1x * pbx - A1z * ptotz - Etot);
+            const double a = - 2 * (B1x * pbx - B1z * ptotz - pby) / fac;
+            const double b = - (SQ(Etot) + pow(C1x + pbx, 2) + pow(C1z - ptotz, 2) + sq_m2 - SQ(C1x) - SQ(pby) - SQ(C1z) - sq_m1) / fac;
 
             const double a20 = 1 - SQ(A1x) - SQ(A1z);
             const double a02 = - (SQ(B1x) + SQ(B1z) + 1);
@@ -208,20 +208,21 @@ class BlockE: public Module {
             const double a01 = - 2 * (B1x * C1x + B1z * C1z + pby);
             const double a00 = SQ(Etot) - (SQ(C1x) + SQ(C1z) + SQ(pby) + sq_m1);
           
-            std::vector<double> E2_sol;
-            const bool foundSolution = solveQuadratic(a20 + SQ(a) * a02 + a * a11, 
-                                                2 * a * b * a02 + b * a11 + a10 + a * a01,
-                                                SQ(b) * a02 + b * a01 + a00,
-                                                E2_sol);
+            std::vector<double> p2y_sol;
+            const bool foundSolution = solveQuadratic(a02 + SQ(a) * a20 + a * a11, 
+                                                2 * a * b * a20 + b * a11 + a01 + a * a10,
+                                                SQ(b) * a20 + b * a10 + a00,
+                                                p2y_sol);
 
             if (!foundSolution)
                 return Status::NEXT;
             
-            for (const double E2: E2_sol) {
+            for (const double p2y: p2y_sol) {
+                const double E2 = a * p2y + b;
+
                 if (E2 <= 0)
                     continue;
-
-                const double p2y = a * E2 + b;
+                
                 const double E1 = Etot - E2;
                 
                 if (E1 <= 0)


### PR DESCRIPTION
As announced in #134, this PR adds support for massive invisible particles in block F.

Most of the code for the solution is actually the same between the two blocks... Not sure it's good to have so much duplicate code, but I don't see a clean way to avoid it while keeping things clear and efficient :/

Strange thing: when simply re-using the expressions of #134 for block F, the validation would converge much, much slower. The only difference was one equation solved in a slightly different way (mathematically equivalent), but it seems to have an important impact numerically. Since the way it was done previously in block F worked much better, I modified block E in this PR to do it in the same way.

Like that things seem to work but I confess I don't understand why one works better than the other...