### PR TITLE
Blocks B and D: support for massive invisibles

### DIFF
--- a/modules/BlockE.cc
+++ b/modules/BlockE.cc
@@ -207,7 +207,7 @@ class BlockE: public Module {
             const double a10 = - 2 * (A1x * C1x + A1z * C1z + Etot);
             const double a01 = - 2 * (B1x * C1x + B1z * C1z + pby);
             const double a00 = SQ(Etot) - (SQ(C1x) + SQ(C1z) + SQ(pby) + sq_m1);
-          
+ 
             std::vector<double> p2y_sol;
             const bool foundSolution = solveQuadratic(a02 + SQ(a) * a20 + a * a11, 
                                                 2 * a * b * a20 + b * a11 + a01 + a * a10,
@@ -216,18 +216,18 @@ class BlockE: public Module {
 
             if (!foundSolution)
                 return Status::NEXT;
-            
+ 
             for (const double p2y: p2y_sol) {
                 const double E2 = a * p2y + b;
 
                 if (E2 <= 0)
                     continue;
-                
+ 
                 const double E1 = Etot - E2;
-                
+ 
                 if (E1 <= 0)
                     continue;
-                
+ 
                 const double p1x = A1x * E2 + B1x * p2y + C1x;
                 const double p1y = - p2y - pby;
                 const double p1z = A1z * E2 + B1z * p2y + C1z;

--- a/modules/SecondaryBlockA.cc
+++ b/modules/SecondaryBlockA.cc
@@ -51,12 +51,17 @@
  *   |------|------|--------------|
  *   | `energy` | double | Collision energy. |
  *
+ * ### Parameters
+ *
+ *   | Name | Type | %Description |
+ *   |------|------|--------------|
+ *   | `m1` | double, default 0 | Mass of the invisible particle \f$p_1\f$. |
+ *
  * ### Inputs
  *
  *   | Name | Type | %Description |
  *   |------|------|--------------|
  *   | `s12` <br/> `s123` <br/> `s1234` | double | Squared invariant mass of the propagators (GeV\f$^2\f$). |
- *   | `p1` | LorentzVector | LorentzVector of the particle we want to reconstruct. This input will be used only to fix the mass of \f$p_1\f$. |
  *   | `p2` <br/> `p3` <br/> `p4` | LorentzVector | LorentzVector of the decay products used to reconstruct \f$p_1\f$ (see above description).|
  *
  * ### Outputs
@@ -80,7 +85,8 @@ class SecondaryBlockA: public Module {
                 s123 = get<double>(parameters.get<InputTag>("s123"));
                 s1234 = get<double>(parameters.get<InputTag>("s1234"));
                 
-                m_p1 = get<LorentzVector>(parameters.get<InputTag>("p1"));
+                m1 = parameters.get<double>("m1", 0.);
+            
                 m_p2 = get<LorentzVector>(parameters.get<InputTag>("p2"));
                 m_p3 = get<LorentzVector>(parameters.get<InputTag>("p3"));
                 m_p4 = get<LorentzVector>(parameters.get<InputTag>("p4"));
@@ -94,8 +100,6 @@ class SecondaryBlockA: public Module {
             if (*s12 > SQ(sqrt_s) || *s123 > SQ(sqrt_s) || *s1234 > SQ(sqrt_s) || *s12 > *s123 || *s123 > *s1234 )
                return Status::NEXT;
 
-            // p1: retrieve the desired mass of the missing particle
-            const double m1 = m_p1->M();
             const double sq_m1 = SQ(m1);
 
             // Store things we might need more than once
@@ -179,7 +183,7 @@ class SecondaryBlockA: public Module {
                 const double p1y = Ay * E1 + By;
                 const double p1z = Az * E1 + Bz;
 
-                LorentzVector p1_sol(p1x, p1y, p1z, E1);
+                LorentzVector p1(p1x, p1y, p1z, E1);
 
                 // Compute jacobian
                 const double jacobian = 1. / (128 * std::pow(M_PI, 3) * std::abs( 
@@ -190,7 +194,7 @@ class SecondaryBlockA: public Module {
                                             E3 * (-(p1z*p2y*p4x) + p1y*p2z*p4x + p1z*p2x*p4y - p1x*p2z*p4y - p1y*p2x*p4z + p1x*p2y*p4z)
                                     ));
 
-                Solution solution { { p1_sol }, jacobian, true };
+                Solution solution { { p1 }, jacobian, true };
                 solutions->push_back(solution);
             }
             
@@ -200,12 +204,12 @@ class SecondaryBlockA: public Module {
 
     private:
         double sqrt_s;
+        double m1;
 
         // Inputs
         Value<double> s12;
         Value<double> s123;
         Value<double> s1234;
-        Value<LorentzVector> m_p1;
         Value<LorentzVector> m_p2;
         Value<LorentzVector> m_p3;
         Value<LorentzVector> m_p4;

--- a/tests/phaseSpaceVolume/blockB_secondaryBlockA.cc
+++ b/tests/phaseSpaceVolume/blockB_secondaryBlockA.cc
@@ -37,13 +37,12 @@ int main(int argc, char** argv) {
     ConfigurationReader configuration("../tests/phaseSpaceVolume/blockB_secondaryBlockA.lua");
     MoMEMta weight(configuration.freeze());
 
-    Particle p1 { "p1", LorentzVector(-25, 0, 0, 25), 0 };
     Particle p2 { "p2", LorentzVector(0, 50, 0, 50), 0 };
     Particle p3 { "p3", LorentzVector(0, 0, 30, 30), 0 };
     Particle p4 { "p4", LorentzVector(50, 0, 0, 50), 0 };
 
     auto start_time = system_clock::now();
-    std::vector<std::pair<double, double>> weights = weight.computeWeights({ p1, p2, p3, p4 });
+    std::vector<std::pair<double, double>> weights = weight.computeWeights({ p2, p3, p4 });
     auto end_time = system_clock::now();
 
     LOG(debug) << "Result:";

--- a/tests/phaseSpaceVolume/blockB_secondaryBlockA.lua
+++ b/tests/phaseSpaceVolume/blockB_secondaryBlockA.lua
@@ -1,4 +1,3 @@
-local p1 = declare_input("p1")
 local p2 = declare_input("p2")
 local p3 = declare_input("p3")
 local p4 = declare_input("p4")
@@ -118,7 +117,6 @@ SecondaryBlockA.secBlockA = {
     s12 = 'flatter_s12::s',
     s123 = 'flatter_s123::s',
     s1234 = 'flatter_s1234::s',
-    p1 = p1.reco_p4,
     p2 = inputs[1],
     p3 = inputs[2],
     p4 = inputs[3]


### PR DESCRIPTION
NB: based on #135 

Modify Main Blocks B and D to support massive invisible particles.

I've also modified the secondary block A to harmonise the way the invisibles' masses are specified. For the moment the rule is the following:
- if the particle is fully reconstructed by the block, the mass is taken from a parameter
- if some quantity of the reconstructed particle is given by the user through an input 4-vector (typically, angles), the particle's mass is also taken from the input vector and not through a parameter (see e.g. the other secondary blocks).
Thoughts on this?