### PR TITLE
Add unit tests for all blocks (except main block C)

### DIFF
--- a/include/momemta/ParameterSet.h
+++ b/include/momemta/ParameterSet.h
@@ -135,9 +135,25 @@ class ParameterSet {
                                 std::is_same<T, InputTag>::value>::type set(const std::string& name, const T& value) {
             set_helper(name, value);
         }
+        
+        /**
+         * \brief Change the value of a given parameter. If the parameter does not exist, it's first created.
+         *
+         * Partial specialization for std::vector.
+         *
+         * \param name The name of the parameter to change
+         * \param value The new value of the parameter
+         */
         template<typename T>
-        typename std::enable_if<std::is_same<T, bool>::value ||
-                                std::is_same<T, InputTag>::value>::type set(const std::string& name, const std::vector<T>& value) {
+        void set(const std::string& name, const std::vector<T>& value) {
+            static_assert(
+                    std::is_same<T, int64_t>::value ||
+                    std::is_same<T, double>::value ||
+                    std::is_same<T, bool>::value ||
+                    std::is_same<T, std::string>::value ||
+                    std::is_same<T, InputTag>::value,
+                    "Type not supported"
+            );
             set_helper(name, value);
         }
 
@@ -148,8 +164,6 @@ class ParameterSet {
          *
          * \param name The name of the parameter to change
          * \param value The new value of the parameter
-         *
-         * \warning Vectors are currently not supported
          */
         template<typename T>
         typename std::enable_if<is_string<T>::value>::type set(const std::string& name, const T& value) {
@@ -163,8 +177,6 @@ class ParameterSet {
          *
          * \param name The name of the parameter to change
          * \param value The new value of the parameter
-         *
-         * \warning Vectors are currently not supported
          */
         template<typename T>
         typename std::enable_if<std::is_integral<T>::value && !std::is_same<T, bool>::value>::type set(const std::string& name, const T& value) {
@@ -178,8 +190,6 @@ class ParameterSet {
          *
          * \param name The name of the parameter to change
          * \param value The new value of the parameter
-         *
-         * \warning Vectors are currently not supported
          */
         template<typename T>
         typename std::enable_if<std::is_floating_point<T>::value>::type set(const std::string& name, const T& value) {

--- a/include/momemta/ParameterSet.h
+++ b/include/momemta/ParameterSet.h
@@ -129,12 +129,15 @@ class ParameterSet {
          *
          * \param name The name of the parameter to change
          * \param value The new value of the parameter
-         *
-         * \warning Vectors are currently not supported
          */
         template<typename T>
         typename std::enable_if<std::is_same<T, bool>::value ||
                                 std::is_same<T, InputTag>::value>::type set(const std::string& name, const T& value) {
+            set_helper(name, value);
+        }
+        template<typename T>
+        typename std::enable_if<std::is_same<T, bool>::value ||
+                                std::is_same<T, InputTag>::value>::type set(const std::string& name, const std::vector<T>& value) {
             set_helper(name, value);
         }
 
@@ -281,7 +284,12 @@ class ParameterSet {
                     std::is_same<T, double>::value ||
                     std::is_same<T, bool>::value ||
                     std::is_same<T, std::string>::value ||
-                    std::is_same<T, InputTag>::value,
+                    std::is_same<T, InputTag>::value ||
+                    std::is_same<T, std::vector<int64_t>>::value ||
+                    std::is_same<T, std::vector<double>>::value ||
+                    std::is_same<T, std::vector<bool>>::value ||
+                    std::is_same<T, std::vector<std::string>>::value ||
+                    std::is_same<T, std::vector<InputTag>>::value,
                     "Type not supported"
             );
 

--- a/modules/BlockE.cc
+++ b/modules/BlockE.cc
@@ -70,7 +70,7 @@
  *
  *   | Name | Type | %Description |
  *   |------|------|-------------|
- *   | `y` | double | Rapidity of the total system. |
+ *   | `y_tot` | double | Rapidity of the total system. |
  *   | `s_hat` | double | Squared invariant mass of the total system. |
  *   | `s13` <br/> `s24` | double | Squared invariant masses of the two propagators, used to reconstruct the event according to the above method. Typically coming from a BreitWignerGenerator module. |
  *   | `p3` <br/> `p4` | LorentzVector | LorentzVectors of the two particles used to reconstruct the event according to the above method. |

--- a/tests/unit_tests/ParameterSet.cc
+++ b/tests/unit_tests/ParameterSet.cc
@@ -58,6 +58,14 @@ TEST_CASE("ParameterSet unit tests", "[core]") {
         REQUIRE(p.get<InputTag>("parameter") == v);
     }
 
+    SECTION("Adding vectors") {
+        REQUIRE_FALSE(p.existsAs<std::vector<double>>("parameter"));
+
+        p.set("parameter", std::vector<double>({10, 20, 30}));
+
+        REQUIRE(p.existsAs<std::vector<double>>("parameter"));
+    }
+
     SECTION("Implicit int64_t cast") {
         REQUIRE_FALSE(p.existsAs<int64_t>("parameter"));
 


### PR DESCRIPTION
Title says all!

It's been quite a pain to find dummy values for which the blocks actually returned solutions that could be tested... There might be a better way of doing that, to also cover the cases where the blocks are supposed not to return any solutions.

Regarding #140: I've left the plain `Approx` for now... Problem is, depending on the block, on the block inputs, on the value that is tested (`sX`, `M()`, `Pt()`), the precision varies quite a lot. 
We could try to find a common minimum value that works everywhere and would be sufficiently small to spot any problems (which is the point of those tests), but isn't the defaut value good enough for that purpose?