### PR TITLE
Refactor Travis configuration and add build with clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,161 @@
-os: [linux]
-sudo: required
+os: linux
 dist: trusty
-
 language: cpp
-compiler:
-  - gcc
-env:
-  global:
-    - PYTHON=true
-  matrix:
-    - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.2.1
-    - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.5.2
-    - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.6.1
-    - ROOT_VERSION=5.34.25 CMAKE_VERSION=3.6.1
-    - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.6.1 PYTHON=false
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-4.9
-      - g++-4.9
-      - libboost1.55-dev
-      - graphviz
+compiler: gcc
+
+matrix:
+  exclude:
+    compiler: gcc
+
+  include:
+
+    ## GCC 4.9
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.9
+            - g++-4.9
+            - libboost1.55-dev
+            - libboost-python1.55-dev
+            - graphviz
+      compiler: gcc
+      env:
+        - COMPILER_EVAL="export CC=gcc-4.9 && export CXX=g++-4.9"
+        - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.6.1 PYTHON=TRUE COVERAGE=ON
+
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.9
+            - g++-4.9
+            - libboost1.55-dev
+            - libboost-python1.55-dev
+            - graphviz
+      compiler: gcc
+      env:
+        - COMPILER_EVAL="export CC=gcc-4.9 && export CXX=g++-4.9"
+        - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.5.2 PYTHON=TRUE COVERAGE=OFF
+
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.9
+            - g++-4.9
+            - libboost1.55-dev
+            - libboost-python1.55-dev
+            - graphviz
+      compiler: gcc
+      env:
+        - COMPILER_EVAL="export CC=gcc-4.9 && export CXX=g++-4.9"
+        - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.2.1 PYTHON=TRUE COVERAGE=OFF
+
+    # GCC 4.9, old ROOT release
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.9
+            - g++-4.9
+            - libboost1.55-dev
+            - libboost-python1.55-dev
+            - graphviz
+      compiler: gcc
+      env:
+        - COMPILER_EVAL="export CC=gcc-4.9 && export CXX=g++-4.9"
+        - ROOT_VERSION=5.34.25 CMAKE_VERSION=3.6.1 PYTHON=TRUE COVERAGE=OFF
+
+    # GCC 4.9, without python bindings
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.9
+            - g++-4.9
+            - libboost1.55-dev
+            - graphviz
+      compiler: gcc
+      env:
+        - COMPILER_EVAL="export CC=gcc-4.9 && export CXX=g++-4.9"
+        - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.6.1 PYTHON=FALSE COVERAGE=OFF
+
+    # GCC 5
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+            - g++-5
+            - libboost1.55-dev
+            - libboost-python1.55-dev
+            - graphviz
+      compiler: gcc
+      env:
+        - COMPILER_EVAL="export CC=gcc-5 && export CXX=g++-5"
+        - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.6.1 PYTHON=TRUE COVERAGE=OFF
+
+    # GCC 6
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-6
+            - g++-6
+            - libboost1.55-dev
+            - libboost-python1.55-dev
+            - graphviz
+      compiler: gcc
+      env:
+        - COMPILER_EVAL="export CC=gcc-6 && export CXX=g++-6"
+        - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.6.1 PYTHON=TRUE COVERAGE=OFF
+
+    # clang
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - g++-4.9
+            - clang-4.0
+            - libboost1.55-dev
+            - libboost-python1.55-dev
+            - graphviz
+      compiler: clang-4.0
+      env:
+        - COMPILER_EVAL="export CC=clang-4.0 && export CXX=clang++-4.0"
+        - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.6.1 PYTHON=TRUE COVERAGE=OFF
+
 before_install:
+  - eval "${COMPILER_EVAL}" 
   - ./travis/decrypt_key.sh
   - pip install --user cpp-coveralls
-  - if [[ $PYTHON == 'true' ]]; then sudo apt-get -y install libboost-python1.55-dev; fi
+
 install:
-  - export CXX=g++-4.9
-  - export CC=gcc-4.9
+  - eval "${COMPILER_EVAL}" 
   - source travis/get-cmake.sh
   - source travis/get-root.sh
   - source travis/get-lhapdf.sh
   - if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then source travis/get-doxygen.sh; fi
+
 before_script:
-  - export CXX=g++-4.9
-  - export CC=gcc-4.9
+  - eval "${COMPILER_EVAL}" 
   - mkdir build
   - cd build
-  - cmake .. -DTESTS=ON -DCOVERAGE=ON -DPYTHON_BINDINGS=ON -DCMAKE_BUILD_TYPE=Debug
+  - cmake .. -DTESTS=ON -DCOVERAGE=${COVERAGE} -DPYTHON_BINDINGS=ON -DCMAKE_BUILD_TYPE=Debug
+
 script:
   - make -j2 && ./run_tests.sh
+
 after_success:
-  - coveralls -e 'external/' --gcov-options '\-lp' -E '.*CMakeCXXCompilerId\.cpp' -E '.*CMakeCCompilerId\.c' -E '.*feature_tests\.c.*' -E '.*MatrixElements/.*' -E '.*/tests/*.' -r .. &> /dev/null;
+  - if [[ $COVERAGE != 'OFF' ]]; then coveralls -e 'external/' --gcov-options '\-lp' -E '.*CMakeCXXCompilerId\.cpp' -E '.*CMakeCCompilerId\.c' -E '.*feature_tests\.c.*' -E '.*MatrixElements/.*' -E '.*/tests/*.' -r .. &> /dev/null; fi
   - if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then ./make_docs.sh; fi

--- a/include/momemta/impl/logger/common.h
+++ b/include/momemta/impl/logger/common.h
@@ -30,7 +30,7 @@ class formatter;
 class logger;
 
 namespace sinks {
-struct sink;
+class sink;
 }
 
 using formatter_ptr = std::shared_ptr<::logger::formatter>;

--- a/travis/get-lhapdf.sh
+++ b/travis/get-lhapdf.sh
@@ -23,7 +23,7 @@ export PYTHONPATH="$PWD/lib/python2.7/site-packages:$PYTHONPATH"
 
 pushd share/LHAPDF
 
-wget http://www.hepforge.org/archive/lhapdf/pdfsets/6.1/CT10nlo.tar.gz
+wget --no-check-certificate https://www.hepforge.org/archive/lhapdf/pdfsets/6.1/CT10nlo.tar.gz
 tar xf CT10nlo.tar.gz
 
 popd


### PR DESCRIPTION
I started this a while ago and somehow forgot to PR it. This simply refactor a bit the travis configuration and adds a build using clang and more recent gcc version (5 and 6). I also took the opportunity to change two things:
  - In light of the hepforge breakage last week, I disable the SSL certificate check when downloading the PDF. This should prevent the same thing to happen in 3 months when they'll forgot again to renew the certificate :)
  - I also fixed a warning issued when compiling with clang