### PR TITLE
Cuba: always free shared memory

### DIFF
--- a/core/src/MoMEMta.cc
+++ b/core/src/MoMEMta.cc
@@ -244,7 +244,7 @@ std::vector<std::pair<double, double>> MoMEMta::computeWeights(const std::vector
                     batch_size,             // (int) batch size for sampling
                     grid_number,            // (int) grid number, 1-10 => up to 10 grids can be stored, and re-used for other integrands (provided they are not too different)
                     grid_file.c_str(),      // (char*) name of state file => state can be stored and retrieved for further refinement
-                    nullptr,                   // (int*) "spinning cores": -1 || NULL <=> integrator takes care of starting & stopping child processes (other value => keep or retrieve child processes, probably not useful here)
+                    nullptr,                // (void*) "spinning cores": -1 || null <=> integrator takes care of starting & stopping child processes (other value => keep or retrieve child processes, memory NOT FREED!!)
                     &neval,                 // (int*) actual number of evaluations done
                     &nfail,                 // 0=desired accuracy was reached; -1=dimensions out of range; >0=accuracy was not reached
                     mcResult.get(),         // (double*) integration result ([ncomp])

--- a/external/cuba/src/common/stddecl.h
+++ b/external/cuba/src/common/stddecl.h
@@ -215,6 +215,7 @@ enum { uninitialized = 0x61627563 };
   who##Alloc(t); \
   if( t->shmid != -1 ) { \
     t->frame = shmat(t->shmid, NULL, 0); \
+    shmctl(t->shmid, IPC_RMID, NULL); \
     if( t->frame == (void *)-1 ) Abort("shmat"); \
   }
 


### PR DESCRIPTION
Fixes #144 

Cuba uses shared system memory (`shmget()`) to communicate with workers when using parallelisation. We were correctly asking that Cuba manages that memory itself and frees it when the integration is over. Problem is, when the program crashes, interrupts or is killed, that shared memory is not freed!

One solution is to manually check the shared memory entries using `ipcs` and remove them using `ipcrm`, but that's not quite user-friendly. This PR modifies Cuba to mark the shared memory page to be freed by the system as soon as no process is attached to it (which is the case even if the program is killed). This has to be done right after the call to `shmat()`, since that would fail if it is called on a page marked for removal.

I've checked that nothing bad happens when Cuba calls `shmctl()` again to free the memory when the call finishes properly.