### PR TITLE
[CI] add support for CodeCov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       compiler: gcc
       env:
         - COMPILER_EVAL="export CC=gcc-4.9 && export CXX=g++-4.9"
-        - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.6.1 PYTHON=TRUE COVERAGE=ON
+        - ROOT_VERSION=6.06.02 CMAKE_VERSION=3.6.1 PYTHON=TRUE COVERAGE=ON GCOV=gcov-4.9
 
     - addons:
         apt:
@@ -157,5 +157,8 @@ script:
   - make -j2 && ./run_tests.sh
 
 after_success:
-  - if [[ $COVERAGE != 'OFF' ]]; then coveralls -e 'external/' --gcov-options '\-lp' -E '.*CMakeCXXCompilerId\.cpp' -E '.*CMakeCCompilerId\.c' -E '.*feature_tests\.c.*' -E '.*MatrixElements/.*' -E '.*/tests/*.' -r .. &> /dev/null; fi
+  - if [[ $COVERAGE != 'OFF' ]]; then
+      coveralls -e 'external/' --gcov-options '\-lp' -E '.*CMakeCXXCompilerId\.cpp' -E '.*CMakeCCompilerId\.c' -E '.*feature_tests\.c.*' -E '.*MatrixElements/.*' -E '.*/tests/*.' -r .. &> /dev/null;
+      ../travis/get-coverage.sh && bash <(curl -s https://codecov.io/bash) -f lcov.info;
+    fi
   - if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then ./make_docs.sh; fi

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Modular Matrix Element Method implementation.
 
-[![Build Status](https://travis-ci.org/MoMEMta/MoMEMta.svg?branch=master)](https://travis-ci.org/MoMEMta/MoMEMta) [![Coverage Status](https://coveralls.io/repos/github/MoMEMta/MoMEMta/badge.svg?branch=master)](https://coveralls.io/github/MoMEMta/MoMEMta?branch=master)
+[![Build Status](https://travis-ci.org/MoMEMta/MoMEMta.svg?branch=master)](https://travis-ci.org/MoMEMta/MoMEMta) [![Coverage Status](https://coveralls.io/repos/github/MoMEMta/MoMEMta/badge.svg?branch=master)](https://coveralls.io/github/MoMEMta/MoMEMta?branch=master) [![codecov](https://codecov.io/gh/MoMEMta/MoMEMta/branch/master/graph/badge.svg)](https://codecov.io/gh/MoMEMta/MoMEMta)
 
 ## Install
 

--- a/travis/get-coverage.sh
+++ b/travis/get-coverage.sh
@@ -1,0 +1,31 @@
+#! /usr/bin/env bash
+
+# Install lcov
+mkdir -p coverage
+cd coverage
+
+wget https://github.com/linux-test-project/lcov/releases/download/v1.13/lcov-1.13.tar.gz &> /dev/null
+tar xf "lcov-1.13.tar.gz"
+cd "lcov-1.13"
+
+make PREFIX=$PWD/../lcov install &> /dev/null
+
+PATH="$PWD/../lcov/bin:$PATH"
+
+cd ../..
+
+ROOT='..'
+OUTPUT='lcov.info'
+GCOV_PATH=$(which $GCOV)
+
+echo "Generating code coverage..."
+lcov -q --gcov-tool "$GCOV_PATH" --directory $ROOT --base-directory $ROOT --capture --output-file $OUTPUT
+
+# Exclude some files
+EXCLUSIONS=('/usr/*' '*CMakeCXXCompilerId.cpp' '*CMakeCCompilerId.c' '*feature_tests.c*' '*MatrixElements/*' '*/tests/*' '*/MoMEMta/build/*' '*/external/*')
+
+for E in "${EXCLUSIONS[@]}"; do
+    lcov -q --gcov-tool "$GCOV_PATH" --remove $OUTPUT "$E" --output-file $OUTPUT
+done
+
+lcov --list $OUTPUT


### PR DESCRIPTION
I just came across CodeCov (https://codecov.io), which looks like a nice alternative to Coveralls. Nice addition is that there's a bot automatically comment all PRs with coverage status.

This PR adds support for it, since it's free :+1:.