### PR TITLE
Keep track of changes done to cuba

### DIFF
--- a/external/cuba/patches/0001-Increase-cuba-notzero-threshold.patch
+++ b/external/cuba/patches/0001-Increase-cuba-notzero-threshold.patch
@@ -1,0 +1,13 @@
+diff --git a/external/cuba/src/common/stddecl.h b/external/cuba/src/common/stddecl.h
+index 7debdd0..57b99da 100644
+--- a/external/cuba/src/common/stddecl.h
++++ b/external/cuba/src/common/stddecl.h
+@@ -121,7 +121,7 @@ enum { uninitialized = 0x61627563 };
+ #define POW2(n) ldexp(1., -n)
+ #endif
+ 
+-#define NOTZERO POW2(104)
++#define NOTZERO POW2(250)
+ 
+ #define ABORT -999
+ 

--- a/external/cuba/patches/0002-Fix-cuba-Fork-in-release-mode-92.patch
+++ b/external/cuba/patches/0002-Fix-cuba-Fork-in-release-mode-92.patch
@@ -1,0 +1,21 @@
+diff --git a/external/cuba/src/common/Fork.c b/external/cuba/src/common/Fork.c
+index 99605d2..5000b9f 100644
+--- a/external/cuba/src/common/Fork.c
++++ b/external/cuba/src/common/Fork.c
+@@ -95,9 +95,13 @@ Extern void SUFFIX(cubafork)(Spin **pspin)
+   for( core = -spin->spec.naccel; core < spin->spec.ncores; ++core ) {
+     int fd[2];
+     pid_t pid;
+-    assert(
+-      socketpair(AF_LOCAL, SOCK_STREAM, 0, fd) != -1 &&
+-      (pid = fork()) != -1 );
++    if (socketpair(AF_LOCAL, SOCK_STREAM, 0, fd) == -1)
++      perror("Error while opening socket");
++
++    pid = fork();
++    if (pid == -1)
++      perror("Error while forking process");
++
+     if( pid == 0 ) {
+       close(fd[0]);
+       free(spin);

--- a/external/cuba/patches/0003-Redirect-cuba-logging-to-our-own-logger-98.patch
+++ b/external/cuba/patches/0003-Redirect-cuba-logging-to-our-own-logger-98.patch
@@ -1,0 +1,106 @@
+diff --git a/external/cuba/cuba.h b/external/cuba/cuba.h
+index 5e87ef1..650cf55 100644
+--- a/external/cuba/cuba.h
++++ b/external/cuba/cuba.h
+@@ -20,6 +20,8 @@ typedef int (*integrand_t)(const int *ndim, const cubareal x[],
+ typedef void (*peakfinder_t)(const int *ndim, const cubareal b[],
+   int *n, cubareal x[], void *userdata);
+ 
++typedef void (*logging_callback)(const char*);
++
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+@@ -119,6 +121,8 @@ void cubaaccel(const int n, const int p);
+ void cubainit(void (*f)(), void *arg);
+ void cubaexit(void (*f)(), void *arg);
+ 
++void cubalogging(logging_callback);
++
+ #ifdef __cplusplus
+ }
+ #endif
+diff --git a/external/cuba/src/common/Data.c b/external/cuba/src/common/Data.c
+index 3d40591..2e5d1fd 100644
+--- a/external/cuba/src/common/Data.c
++++ b/external/cuba/src/common/Data.c
+@@ -9,10 +9,11 @@
+ #include "stddecl.h"
+ 
+ int cubaverb_ = uninitialized;
++logging_callback logging_function = cubalog_;
+ 
+ #ifdef HAVE_FORK
+ corespec cubaworkers_ = {
+-  uninitialized, uninitialized, 
++  uninitialized, uninitialized,
+   uninitialized, uninitialized };
+ #endif
+ 
+diff --git a/external/cuba/src/common/Global.c b/external/cuba/src/common/Global.c
+index 6e5975f..e29b2de 100644
+--- a/external/cuba/src/common/Global.c
++++ b/external/cuba/src/common/Global.c
+@@ -16,7 +16,6 @@ extern int cubaverb_;
+ extern corespec cubaworkers_;
+ #endif
+ 
+-
+ Extern void SUFFIX(cubaverbose)(cint verb)
+ {
+   cubaverb_ = verb;
+@@ -56,3 +55,9 @@ Extern void SUFFIX(cubaexit)(subroutine f, void *arg)
+   cubafun_.exitarg = arg;
+ }
+ 
++/*********************************************************************/
++
++Extern void SUFFIX(cubalogging)(logging_callback fct)
++{
++    logging_function = fct;
++}
+\ No newline at end of file
+diff --git a/external/cuba/src/common/stddecl.h b/external/cuba/src/common/stddecl.h
+index 1153f03..9ed086f 100644
+--- a/external/cuba/src/common/stddecl.h
++++ b/external/cuba/src/common/stddecl.h
+@@ -227,7 +227,7 @@ enum { uninitialized = 0x61627563 };
+ #endif
+ #endif
+ #endif
+-  
++
+ #define FrameAlloc(t, who) \
+   SHM_ONLY(ShmAlloc(t, who) else) \
+   MemAlloc(t->frame, t->nframe*SAMPLESIZE);
+@@ -408,6 +408,9 @@ typedef const real creal;
+ 
+ typedef void (*subroutine)(void *, cint *);
+ 
++typedef void (*logging_callback)(const char*);
++extern logging_callback logging_function;
++
+ typedef struct {
+   subroutine initfun;
+   void *initarg;
+@@ -512,6 +515,11 @@ static inline real Weight(creal sum, creal sqsum, cnumber n) {
+   return (n - 1)/Max((w + sum)*(w - sum), NOTZERO);
+ }
+ 
++static inline void cubalog_(const char* s) {
++  puts(s);
++  fflush(stdout);
++}
++
+ 
+ /* (a < 0) ? -1 : 0 */
+ #define NegQ(a) ((a) >> (sizeof(a)*8 - 1))
+@@ -553,7 +561,7 @@ static inline void Print(MLCONST char *s)
+ 
+ #else
+ 
+-#define Print(s) puts(s); fflush(stdout)
++#define Print(s) (logging_function(s));
+ 
+ #endif
+ 

--- a/external/cuba/patches/0004-Add-clang-compatibility-99.patch
+++ b/external/cuba/patches/0004-Add-clang-compatibility-99.patch
@@ -1,0 +1,13 @@
+diff --git a/external/cuba/src/divonne/Sample.c b/external/cuba/src/divonne/Sample.c
+index 113b6ae..0b535ab 100644
+--- a/external/cuba/src/divonne/Sample.c
++++ b/external/cuba/src/divonne/Sample.c
+@@ -86,7 +86,7 @@ static void SampleKorobov(This *t, ccount iregion)
+   for( i = 1; i < n; ++i ) {
+     number c = i;
+     for( dim = 0; dim < t->ndim; ++dim ) {
+-      creal dx = abs(2*c - neff)/(real)neff;
++      creal dx = llabs(2*c - neff)/(real)neff;
+       *xlast++ = b[dim].lower + dx*(b[dim].upper - b[dim].lower);
+       c = c*samples->coeff % neff;
+     }

--- a/external/cuba/patches/0005-Fix-build-with-GCC-6.2-116.patch
+++ b/external/cuba/patches/0005-Fix-build-with-GCC-6.2-116.patch
@@ -1,0 +1,12 @@
+diff --git a/external/cuba/src/common/stddecl.h b/external/cuba/src/common/stddecl.h
+index 9ed086f..c09f69e 100644
+--- a/external/cuba/src/common/stddecl.h
++++ b/external/cuba/src/common/stddecl.h
+@@ -14,6 +14,7 @@
+ 
+ #define _BSD_SOURCE
+ #define _SVID_SOURCE
++#define _DEFAULT_SOURCE
+ 
+ #include <stdio.h>
+ #include <stdlib.h>

--- a/external/cuba/patches/0006-Cuba-always-free-shared-memory.patch
+++ b/external/cuba/patches/0006-Cuba-always-free-shared-memory.patch
@@ -1,0 +1,12 @@
+diff --git a/external/cuba/src/common/stddecl.h b/external/cuba/src/common/stddecl.h
+index c09f69e..7debdd0 100644
+--- a/external/cuba/src/common/stddecl.h
++++ b/external/cuba/src/common/stddecl.h
+@@ -215,6 +215,7 @@ enum { uninitialized = 0x61627563 };
+   who##Alloc(t); \
+   if( t->shmid != -1 ) { \
+     t->frame = shmat(t->shmid, NULL, 0); \
++    shmctl(t->shmid, IPC_RMID, NULL); \
+     if( t->frame == (void *)-1 ) Abort("shmat"); \
+   }
+ 

--- a/scripts/generate_patches.sh
+++ b/scripts/generate_patches.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+DIR=$PWD
+
+[[ -d patches ]] || mkdir patches
+
+COMMITS=$(git log --reverse --format="format:%H" -- "$DIR" ":!*CMakeLists.txt")
+
+COUNTER=1
+for SHA1 in $COMMITS; do
+
+    filename=$(printf "%04d" $COUNTER)-$(git log --format=%f -n 1 ${SHA1}).patch
+
+    # Generate diff
+    git diff -u -p ${SHA1}^..${SHA1} -- "$DIR" ":!*CMakeLists.txt" > "patches/${filename}"
+
+    ((COUNTER++))
+done


### PR DESCRIPTION
This PR adds a set of patches of all the changes we've done to cuba, in order to easily reapply everything if ever a new version of cuba is released.