### PR TITLE
Fix compatibility with recent Doxygen versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,7 +384,7 @@ add_custom_target(uninstall
 # Documentation
 
 # add a target to generate API documentation with Doxygen
-find_package(Doxygen)
+find_package(Doxygen 1.8.12)
 if(DOXYGEN_FOUND)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docs/theme/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docs/tools/make_docs.sh.in ${CMAKE_CURRENT_BINARY_DIR}/make_docs.sh @ONLY)

--- a/docs/theme/footer.html
+++ b/docs/theme/footer.html
@@ -22,5 +22,8 @@ $generatedby &#160;<a href="http://www.doxygen.org/index.html">
 </a> $doxygenversion
 </small></address>
 <!--END !GENERATE_TREEVIEW-->
+
+<script type="text/javascript" src="$relpath^doxy-boot.js"></script>
+
 </body>
 </html>

--- a/docs/theme/header.html
+++ b/docs/theme/header.html
@@ -14,9 +14,14 @@
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-scrollTo/2.1.2/jquery.scrollTo.min.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-powertip/1.2.0/jquery.powertip.min.js"></script>
 
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.smartmenus/1.0.1/jquery.smartmenus.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.smartmenus/1.0.1/addons/keyboard/jquery.smartmenus.keyboard.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.smartmenus/1.0.1/addons/bootstrap/jquery.smartmenus.bootstrap.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/highlight.min.js"></script>
+
         <!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
         <!--BEGIN !PROJECT_NAME--><title>$title</title><!--END !PROJECT_NAME-->
-        <!--<link href="$relpath^tabs.css" rel="stylesheet" type="text/css"/>-->
+
         <script type="text/javascript" src="$relpath^dynsections.js"></script>
         $treeview
         $search
@@ -27,8 +32,7 @@
         $extrastylesheet
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/styles/solarized-light.min.css">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/highlight.min.js"></script>
-        <script type="text/javascript" src="$relpath^doxy-boot.js"></script>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery.smartmenus/1.0.1/addons/bootstrap/jquery.smartmenus.bootstrap.min.css">
     </head>
     <body>
         <nav class="navbar navbar-default" role="navigation">

--- a/travis/get-doxygen.sh
+++ b/travis/get-doxygen.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
-doxygen_VERSION=1.8.11
-BUNDLE=doxygen-${doxygen_VERSION}_Python-2.7_gcc-4.9.3_Ubuntu_14.04_x86_64
+doxygen_VERSION=1.8.13
+BUNDLE=doxygen-${doxygen_VERSION}_Python-2.7_gcc-4.9_Ubuntu_14.04_x86_64
 
 mkdir -p external/doxygen
 cd external/doxygen


### PR DESCRIPTION
Recenr Doxygen version changed the way the top menu is handled, breaking the custom theme we are using. This PR adapts the code to be compatible with these new releases. As a consequence, we now require at least Doxygen 1.8.12. Travis doxygen version has been updated to the latest one (1.8.13).