### PR TITLE
Fix spurious h2 in doxygen doc

### DIFF
--- a/docs/theme/customdoxygen.css
+++ b/docs/theme/customdoxygen.css
@@ -407,3 +407,7 @@ pre .line::before {
     padding-right: 0.5em; margin-right: 0.5em;
     color: #839496; border-right: 1px solid #e0e0e0 !important;
 }
+
+h2.memtitle {
+  display: none;
+}


### PR DESCRIPTION
See https://momemta.github.io/MoMEMta/dev/classModule.html#a43c0b7c70e9dd8b0cf6c78aa5052eeee for an example of what this fixes (the big work with the small diamond on its left).