### PR TITLE
Fix Block B

### DIFF
--- a/modules/BlockB.cc
+++ b/modules/BlockB.cc
@@ -177,13 +177,6 @@ class BlockB: public Module {
                 if (q1Pz > sqrt_s / 2 || q2Pz > sqrt_s / 2)
                     continue;
 
-                if (!ApproxComparison(tot.Pt(), 0)) {
-#ifndef NDEBUG
-                    LOG(trace) << "[BlockB] Throwing solution because total Pt is not null: " << tot.Pt();
-#endif
-                    continue;
-                }
-
                 if (!ApproxComparison(p1.M() / p1.E(), m1 / p1.E())) {
 #ifndef NDEBUG
                     LOG(trace) << "[BlockB] Throwing solution because of invalid mass. " <<
@@ -192,10 +185,10 @@ class BlockB: public Module {
                     continue;
                 }
 
-                if (!ApproxComparison((p1 + pT).M2(), *s12)) {
+                if (!ApproxComparison((p1 + *p2).M2(), *s12)) {
 #ifndef NDEBUG
                     LOG(trace) << "[BlockB] Throwing solution because of invalid invariant mass. " <<
-                               "Expected " << *s12 << ", got " << (p1 + pT).M2();
+                               "Expected " << *s12 << ", got " << (p1 + *p2).M2();
 #endif
                     continue;
                 }

--- a/modules/BlockC.cc
+++ b/modules/BlockC.cc
@@ -54,7 +54,7 @@
  *
  *   | Name | Type | %Description |
  *   |------|------|--------------|
- *   | `pT_is_met` | bool, default false | Fix \f$\vec{p}_{T}^{tot} = -\vec{\cancel{E_T}}\f$ or \f$\vec{p}_{T}^{tot} = \sum_{i \in \text{ vis}} \vec{p}_i\f$ |
+ *   | `pT_is_met` | bool, default false | Fix \f$\vec{p}_{T1} + \vec{p}_{T3} = \vec{\cancel{E_T}}\f$ (i.e. assume particles 1 and 3 are both invisible, and constrain them to the MET) or \f$\vec{p}_{T1} + \vec{p}_{T3} = - \sum_{i \in \text{2, branches}} \vec{p}_i\f$ (enforce zero total transverse momentum no matter what) |
  *   | `m1`  | double, default 0 | Mass of the invisible particle |
  *
  * ### Inputs
@@ -310,3 +310,4 @@ REGISTER_MODULE(BlockC)
         .GlobalAttr("energy:double")
         .Attr("pT_is_met:bool=false")
         .Attr("m1:double=0");
+

--- a/tests/phaseSpaceGeneration/phaseSpaceVolume.cc
+++ b/tests/phaseSpaceGeneration/phaseSpaceVolume.cc
@@ -49,7 +49,7 @@ int main(int argc, char** argv) {
     manager.registerTest({ SOURCE_PATH "/tests/phaseSpaceGeneration/phaseSpaceVolume/blockD.lua", { "p1", "p2", "p3", "p4" }, { 0, 0, 0, 0 }, massless_phase_space(1000, 6) }, 'D');
     manager.registerTest({ SOURCE_PATH "/tests/phaseSpaceGeneration/phaseSpaceVolume/blockE.lua", { "p1", "p3" }, { 0, 0 }, massless_phase_space(1000, 4) }, 'E');
     manager.registerTest({ SOURCE_PATH "/tests/phaseSpaceGeneration/phaseSpaceVolume/blockF.lua", { "p1", "p2" }, { 0, 0 }, massless_phase_space(1000, 4) }, 'F');
-    manager.registerTest({ SOURCE_PATH "/tests/phaseSpaceGeneration/phaseSpaceVolume/blockG.lua", { "p1", "p2", "p3", "p4" }, { 0, 0, 0, 0 }, massless_phase_space(1000, 3) }, 'G');
+    manager.registerTest({ SOURCE_PATH "/tests/phaseSpaceGeneration/phaseSpaceVolume/blockG.lua", { "p1", "p2", "p3", "p4" }, { 0, 0, 0, 0 }, massless_phase_space(1000, 4) }, 'G');
 
     manager.parseArgs(argc, argv);
 

--- a/tests/phaseSpaceGeneration/phaseSpaceVolume/README.md
+++ b/tests/phaseSpaceGeneration/phaseSpaceVolume/README.md
@@ -68,6 +68,11 @@ NUMA node1 CPU(s):     12-23,36-47
 
   - Runtime: 15481.15user 7.44system 38:41.82elapsed
   - 645.063 +- 4.45919 (incorrect, we should tweak integration parameters)
+
+## Block E
+
+- Runtime: 2638,41s user 1,46s system 769% cpu 5:43,18 total
+- 0.016599 +- 3.027e-05
  
 ## Block F
 


### PR DESCRIPTION
The checks introduced in #157 for blockB were buggy (my bad, I was the one who requested that particular change).

Also for BlockB, the check for zero total transverse momentum is removed since it's trivially verified from the way the missing particle is reconstructed.

I've also added the PS volume validation for BlockE (no idea why it wasn't there, the value is in agreement with the analytical one) and fixed the reference value for BlockG.