### PR TITLE
Evaluate integrand on single point

### DIFF
--- a/core/src/python/bindings.cc
+++ b/core/src/python/bindings.cc
@@ -40,6 +40,40 @@ void set_log_level(logging::level::level_enum lvl) {
     logging::set_level(lvl);
 }
 
+void MoMEMta_setEvent_MET(MoMEMta& m, bp::list particles_, bp::list met_) {
+    std::vector<Particle> particles;
+    for (ssize_t i = 0; i < bp::len(particles_); i++) {
+        particles.push_back(bp::extract<Particle>(particles_[i]));
+    }
+
+    LorentzVector met;
+    bp::extract<LorentzVector> lorentzVectorExtractor(met_);
+    if (lorentzVectorExtractor.check())
+        met = lorentzVectorExtractor();
+
+    m.setEvent(particles, met);
+}
+
+void MoMEMta_setEvent(MoMEMta& m, bp::list particles_) {
+    MoMEMta_setEvent_MET(m, particles_, bp::list());
+}
+
+bp::list MoMEMta_evaluateIntegrand(MoMEMta& m, bp::list psPoint_) {
+    std::vector<double> psPoint;
+    for (ssize_t i = 0; i < bp::len(psPoint_); i++) {
+        psPoint.push_back(bp::extract<double>(psPoint_[i]));
+    }
+
+    auto integrands = m.evaluateIntegrand(psPoint);
+
+    bp::list result;
+    for (const auto& integrand: integrands) {
+        result.append(integrand);
+    }
+
+    return result;
+}
+
 bp::list MoMEMta_computeWeights_MET(MoMEMta& m, bp::list particles_, bp::list met_) {
     std::vector<Particle> particles;
     for (ssize_t i = 0; i < bp::len(particles_); i++) {
@@ -146,6 +180,9 @@ struct convert_py_root_to_cpp_root {
 // Overloads for MoMEMta::computeWeights
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(MoMEMta_computeWeights_overloads, MoMEMta::computeWeights, 1, 2)
 
+// Overloads for MoMEMta::setEvent
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(MoMEMta_setEvent_overloads, MoMEMta::setEvent, 1, 2)
+
 BOOST_PYTHON_MODULE(momemta) {
 
     using namespace boost::python;
@@ -213,5 +250,9 @@ BOOST_PYTHON_MODULE(momemta) {
             //.def("getPool", &MoMEMta::getPool, return_value_policy<copy_const_reference>())
             .def("computeWeights", MoMEMta_computeWeights)
             .def("computeWeights", MoMEMta_computeWeights_MET)
-            .def("computeWeights", &MoMEMta::computeWeights, MoMEMta_computeWeights_overloads());
+            .def("computeWeights", &MoMEMta::computeWeights, MoMEMta_computeWeights_overloads())
+            .def("setEvent", MoMEMta_setEvent)
+            .def("setEvent", MoMEMta_setEvent_MET)
+            .def("setEvent", &MoMEMta::setEvent, MoMEMta_setEvent_overloads())
+            .def("evaluateIntegrand", MoMEMta_evaluateIntegrand);
 }

--- a/include/momemta/MoMEMta.h
+++ b/include/momemta/MoMEMta.h
@@ -73,8 +73,29 @@ class MoMEMta {
          * \return A vector of weights. Each weight is represented by a pair of double, the first element being the value of the weight and the second the associated absolute error.
          */
         std::vector<std::pair<double, double>> computeWeights(const std::vector<momemta::Particle>& particles,
-                                                              const LorentzVector& met = LorentzVector());
+                                                              const LorentzVector& met=LorentzVector());
 
+        /** \brief Set the event particles' momenta
+         *
+         * In public interface mostly for debugging purposes -- for regular usage see the computeWeights() function.
+         *
+         * \param particles List of Particle representing the final state particles.
+         * \param met Missing transverse energy of the event. This parameter is optional.
+         */
+        void setEvent(const std::vector<momemta::Particle>& particles, const LorentzVector& met=LorentzVector());
+        
+        /** \brief Evaluate the integrand on a single phase-space point.
+         *
+         * Mostly for debugging purposes -- for regular usage see the computeWeights function.
+         *
+         * Warning: return value is undefined until setEvent() has been called.
+         *
+         * \param psPoints Phase-space point the integrand will be computed on. It has to lie within the unit hypercube, with the right dimensionality.
+         *
+         * \return The (possibly multi-dimensional) integrand.
+         */
+        std::vector<double> evaluateIntegrand(const std::vector<double>& psPoints);
+        
         /** \brief Return the status of the integration
          *
          * \return The status of the integration
@@ -125,7 +146,7 @@ class MoMEMta {
          */
         void initPool(const Configuration& configuration);
 
-        int integrand(const double* psPoints, double* results, const double* weights);
+        int integrand(const double* psPoints, double* results, const double* weights=nullptr);
 
         static int CUBAIntegrand(const int *nDim, const double* psPoint, const int *nComp, double *value, void *inputs, const int *nVec, const int *core);
         static int CUBAIntegrandWeighted(const int *nDim, const double* psPoint, const int *nComp, double *value, void *inputs, const int *nVec, const int *core, const double *weight);

--- a/tests/bindings/python/integration_tests.py
+++ b/tests/bindings/python/integration_tests.py
@@ -37,10 +37,14 @@ class IntegrationTest(unittest.TestCase):
         self.assertEqual(self.runner.getIntegrationStatus(), momemta.IntegrationStatus.SUCCESS)
 
         self.assertEqual(len(result), 1)
-
         result = result[0]
         self.assertAlmostEquals(result[0], 4.4954322e-21)
         self.assertAlmostEquals(result[1], 2.1120765e-21)
+
+        self.runner.setEvent([p3, p4, p5, p6])
+        result = self.runner.evaluateIntegrand([0.5]*9)
+        self.assertEqual(len(result), 1)
+        self.assertAlmostEquals(result[0], 2.06407675147e-18)
 
     def test_list(self):
 
@@ -54,10 +58,14 @@ class IntegrationTest(unittest.TestCase):
         self.assertEqual(self.runner.getIntegrationStatus(), momemta.IntegrationStatus.SUCCESS)
 
         self.assertEqual(len(result), 1)
-
         result = result[0]
         self.assertAlmostEquals(result[0], 4.4954322e-21)
         self.assertAlmostEquals(result[1], 2.1120765e-21)
+
+        self.runner.setEvent([p3, p4, p5, p6])
+        result = self.runner.evaluateIntegrand([0.5]*9)
+        self.assertEqual(len(result), 1)
+        self.assertAlmostEquals(result[0], 2.06407675147e-18)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/tests/integration_tests/CMakeLists.txt
+++ b/tests/integration_tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    "integrand.cc"
     "no_integration.cc"
     "integration_tests.cc"
     )

--- a/tests/integration_tests/integrand.cc
+++ b/tests/integration_tests/integrand.cc
@@ -30,10 +30,10 @@
 
 using namespace momemta;
 
-TEST_CASE("No integration", "[integration_tests]") {
+TEST_CASE("Integrand evaluation", "[integration_tests]") {
     logging::set_level(logging::level::fatal);
 
-    ConfigurationReader configuration("no_integration.lua");
+    ConfigurationReader configuration("integrand.lua");
     MoMEMta weight(configuration.freeze());
 
     // Electron
@@ -44,16 +44,11 @@ TEST_CASE("No integration", "[integration_tests]") {
     Particle muon { "muon", LorentzVector(-18.9018573760986, 10.0896110534668, -0.602926552295686, 21.4346446990967), +13 };
     // Anti b-quark
     Particle bjet2 { "bjet2", LorentzVector(71.3899612426758, 96.0094833374023, -77.2513122558594, 142.492813110352), -5 };
-    // Electronic neutrino
-    Particle nu1 { "neutrino1", LorentzVector(-57.9413, 40.7629, -54.2982, 89.2587), +12 };
-    // Muonic neutrino
-    Particle nu2 { "neutrino2", LorentzVector(57.9413, -40.7629, -40.8437, 81.7742), -14 };
 
-    std::vector<std::pair<double, double>> weights = weight.computeWeights({electron, muon, bjet1, bjet2, nu1, nu2});
-
-    REQUIRE(weight.getIntegrationStatus() == MoMEMta::IntegrationStatus::SUCCESS);
+    weight.setEvent({electron, muon, bjet1, bjet2});
+    std::vector<double> psPoint { 0.25, 0.15, 0.1, 0.4 };
+    std::vector<double> weights = weight.evaluateIntegrand(psPoint);
 
     REQUIRE(weights.size() == 1);
-    REQUIRE(weights[0].first * 1e13 == Approx(8.36916));
-    REQUIRE(weights[0].second == Approx(0.));
+    REQUIRE(weights[0] * 1e21 == Approx(6.0072644042));
 }

--- a/tests/integration_tests/integrand.lua
+++ b/tests/integration_tests/integrand.lua
@@ -1,0 +1,132 @@
+local electron = declare_input("electron")
+local muon = declare_input("muon")
+local bjet1 = declare_input("bjet1")
+local bjet2 = declare_input("bjet2")
+
+parameters = {
+    energy = 13000.,
+    top_mass = 173.,
+    top_width = 1.491500,
+    W_mass = 80.419002,
+    W_width = 2.047600
+}
+
+BreitWignerGenerator.flatter_s13 = {
+    ps_point = add_dimension(),
+    mass = parameter('W_mass'),
+    width = parameter('W_width')
+}
+
+BreitWignerGenerator.flatter_s134 = {
+    ps_point = add_dimension(),
+    mass = parameter('top_mass'),
+    width = parameter('top_width')
+}
+
+BreitWignerGenerator.flatter_s25 = {
+    ps_point = add_dimension(),
+    mass = parameter('W_mass'),
+    width = parameter('W_width')
+}
+
+BreitWignerGenerator.flatter_s256 = {
+    ps_point = add_dimension(),
+    mass = parameter('top_mass'),
+    width = parameter('top_width')
+}
+
+inputs = {
+    electron.reco_p4,
+    bjet1.reco_p4,
+    muon.reco_p4,
+    bjet2.reco_p4
+}
+
+StandardPhaseSpace.phaseSpaceOut = {
+    particles = inputs
+}
+
+BlockD.blockd = {
+    p3 = inputs[1],
+    p4 = inputs[2],
+    p5 = inputs[3],
+    p6 = inputs[4],
+
+    pT_is_met = true,
+
+    s13 = 'flatter_s13::s',
+    s134 = 'flatter_s134::s',
+    s25 = 'flatter_s25::s',
+    s256 = 'flatter_s256::s',
+}
+
+Looper.looper = {
+    solutions = "blockd::solutions",
+    path = Path("boost", "ttbar", "integrand")
+}
+
+    full_inputs = copy_and_append(inputs, {'looper::particles/1', 'looper::particles/2'})
+
+    BuildInitialState.boost = {
+        do_transverse_boost = true,
+        particles = full_inputs
+    }
+
+    jacobians = {'flatter_s13::jacobian', 'flatter_s134::jacobian', 'flatter_s25::jacobian', 'flatter_s256::jacobian'}
+
+    append(jacobians, {'phaseSpaceOut::phase_space', 'looper::jacobian'})
+
+    MatrixElement.ttbar = {
+      pdf = 'CT10nlo',
+      pdf_scale = parameter('top_mass'),
+
+      matrix_element = 'pp_ttx_fully_leptonic',
+      matrix_element_parameters = {
+          card = '../../MatrixElements/Cards/param_card.dat',
+      },
+
+      initialState = 'boost::partons',
+
+      particles = {
+        inputs = full_inputs,
+        ids = {
+          {
+            pdg_id = -13,
+            me_index = 1,
+          },
+
+          {
+            pdg_id = 5,
+            me_index = 3,
+          },
+
+          {
+            pdg_id = 13,
+            me_index = 4,
+          },
+
+          {
+            pdg_id = -5,
+            me_index = 6,
+          },
+
+          {
+            pdg_id = 14,
+            me_index = 2,
+          },
+
+          {
+            pdg_id = -14,
+            me_index = 5,
+          }
+        }
+      },
+
+      jacobians = jacobians
+    }
+
+    DoubleLooperSummer.integrand = {
+        input = "ttbar::output"
+    }
+
+integrand("integrand::sum")

--- a/tests/integration_tests/no_integration.lua
+++ b/tests/integration_tests/no_integration.lua
@@ -19,6 +19,7 @@ inputs = {
     neutrino2.reco_p4
 }
 
+-- Makes no sense, but let's test it
 StandardPhaseSpace.phaseSpaceOut = {
     particles = {electron.reco_p4, bjet1.reco_p4, muon.reco_p4, bjet2.reco_p4}
 }


### PR DESCRIPTION
As mentioned in #161, this adds the possiblity to call the integrand on a single phase-space point.

To care for the possibility where the user would like to use a custom integrator, I've added a function to set the event 4-momenta beforehand and only pass the phase-space point when computing the integrand.

Note: I'm having some issue with the python bindings on the UCL machines, let's see what Travis thinks of it here.