### PR TITLE
Fix finding LHAPDF

### DIFF
--- a/cmake/modules/FindLHAPDF.cmake
+++ b/cmake/modules/FindLHAPDF.cmake
@@ -10,7 +10,7 @@
 
 find_path(LHAPDF_INCLUDE_DIR LHAPDF/LHAPDF.h HINTS ${LHAPDF_ROOT}
     PATH_SUFFIXES "include")
-find_library(LHAPDF_LIBRARY LHAPDF)
+find_library(LHAPDF_LIBRARY LHAPDF HINTS ${LHAPDF_ROOT} PATH_SUFFIXES lib)
 
 if (NOT LHAPDF_INCLUDE_DIR OR NOT LHAPDF_LIBRARY)
     # Not found, try to look for lhapdf-config


### PR DESCRIPTION
FindLHAPDF.cmake was modified in #107 to support CMSSW, but it does not seem to work (anymore?)...

The workaround is needed in case `lhapdf-config` is not available, which is the case inside a CMSSW environment.

Tested on CMSSW_9_4_5.