### PR TITLE
Set lhapdf path from environment variable

### DIFF
--- a/cmake/modules/FindLHAPDF.cmake
+++ b/cmake/modules/FindLHAPDF.cmake
@@ -8,9 +8,9 @@
 # First try to look for LHAPDF.h in standard path
 # lhapdf-config is not a reliable way to find lhapdf
 
-find_path(LHAPDF_INCLUDE_DIR LHAPDF/LHAPDF.h HINTS ${LHAPDF_ROOT}
+find_path(LHAPDF_INCLUDE_DIR LHAPDF/LHAPDF.h HINTS ${LHAPDF_ROOT} $ENV{LHAPDF_ROOT}
     PATH_SUFFIXES "include")
-find_library(LHAPDF_LIBRARY LHAPDF HINTS ${LHAPDF_ROOT} PATH_SUFFIXES lib)
+find_library(LHAPDF_LIBRARY LHAPDF HINTS ${LHAPDF_ROOT} $ENV{LHAPDF_ROOT} PATH_SUFFIXES lib)
 
 if (NOT LHAPDF_INCLUDE_DIR OR NOT LHAPDF_LIBRARY)
     # Not found, try to look for lhapdf-config


### PR DESCRIPTION
For environments where `LHAPDF_ROOT` is set as environment variable, this makes CMake find it without user intervention.

Note: please don't merge until I've checked with the people who reported the issue if that fixes it completely.