### PR TITLE
Fix GCC 8 warnings

### DIFF
--- a/core/src/InputTag.cc
+++ b/core/src/InputTag.cc
@@ -64,7 +64,7 @@ bool InputTag::isInputTag(const std::string& tag) {
                 return false;
 
             return true;
-        } catch (std::invalid_argument e) {
+        } catch (const std::invalid_argument& e) {
             return false;
         }
     } else {

--- a/core/src/MoMEMta.cc
+++ b/core/src/MoMEMta.cc
@@ -21,6 +21,7 @@
 
 #include <cstring>
 #include <cmath>
+#include <cstdint>
 
 #include <cuba.h>
 
@@ -243,7 +244,7 @@ std::vector<std::pair<double, double>> MoMEMta::computeWeights(const std::vector
         if (algorithm == "vegas") {
             int64_t n_start = m_cuba_configuration.get<int64_t>("n_start", 25000);
             int64_t n_increase = m_cuba_configuration.get<int64_t>("n_increase", 0);
-            int64_t batch_size = m_cuba_configuration.get<int64_t>("batch_size", std::min(n_start, 50000L));
+            int64_t batch_size = m_cuba_configuration.get<int64_t>("batch_size", std::min(n_start, INT64_C(50000)));
             int64_t grid_number = m_cuba_configuration.get<int64_t>("grid_number", 0);
 
             llVegas(

--- a/core/src/MoMEMta.cc
+++ b/core/src/MoMEMta.cc
@@ -250,7 +250,7 @@ std::vector<std::pair<double, double>> MoMEMta::computeWeights(const std::vector
             llVegas(
                     m_n_dimensions,         // (int) dimensions of the integrated volume
                     m_n_components,         // (int) dimensions of the integrand
-                    (integrand_t) CUBAIntegrandWeighted,  // (integrand_t) integrand (cast to integrand_t)
+                    reinterpret_cast<integrand_t>(CUBAIntegrandWeighted),  // (integrand_t) integrand (cast to integrand_t)
                     (void *) this,           // (void*) pointer to additional arguments passed to integrand
                     1,                      // (int) maximum number of points given the integrand in each invocation (=> SIMD) ==> PS points = vector of sets of points (x[ndim][nvec]), integrand returns vector of vector values (f[ncomp][nvec])
                     relative_accuracy,      // (double) requested relative accuracy  /
@@ -281,7 +281,7 @@ std::vector<std::pair<double, double>> MoMEMta::computeWeights(const std::vector
             llSuave(
                     m_n_dimensions,
                     m_n_components,
-                    (integrand_t) CUBAIntegrandWeighted,
+                    reinterpret_cast<integrand_t>(CUBAIntegrandWeighted),
                     (void *) this,
                     1,
                     relative_accuracy,
@@ -316,7 +316,7 @@ std::vector<std::pair<double, double>> MoMEMta::computeWeights(const std::vector
             llDivonne(
                     m_n_dimensions,
                     m_n_components,
-                    (integrand_t) CUBAIntegrand,
+                    reinterpret_cast<integrand_t>(CUBAIntegrand),
                     (void *) this,
                     1,
                     relative_accuracy,
@@ -352,7 +352,7 @@ std::vector<std::pair<double, double>> MoMEMta::computeWeights(const std::vector
             llCuhre(
                     m_n_dimensions,
                     m_n_components,
-                    (integrand_t) CUBAIntegrand,
+                    reinterpret_cast<integrand_t>(CUBAIntegrand),
                     (void *) this,
                     1,
                     relative_accuracy,

--- a/core/src/SLHAReader.cc
+++ b/core/src/SLHAReader.cc
@@ -127,7 +127,7 @@ void Reader::read_slha_file(const std::string& file_name) {
             throw invalid_card_error("No information read from SLHA card");
 
     // End try
-    } catch(std::exception &e) {
+    } catch(const std::exception &e) {
         param_card.close();
         throw e;
     }

--- a/external/cuba/patches/0008-Fix-warnings-GCC-8.patch
+++ b/external/cuba/patches/0008-Fix-warnings-GCC-8.patch
@@ -1,0 +1,42 @@
+diff --git a/external/cuba/src/common/Random.c b/external/cuba/src/common/Random.c
+index 6d60615..38f0b8a 100644
+--- a/external/cuba/src/common/Random.c
++++ b/external/cuba/src/common/Random.c
+@@ -102,7 +102,8 @@ static inline void SobolIni(This *t)
+     int inibits = -1, bit;
+     for( j = powers; j; j >>= 1 ) ++inibits;
+ 
+-    memcpy(pv, pini, inibits*sizeof *pini);
++    if (inibits > 0)
++        memcpy(pv, pini, inibits*sizeof *pini);
+     pini += 8;
+ 
+     for( bit = inibits; bit <= nbits; ++bit ) {
+diff --git a/external/cuba/src/divonne/Rule.c b/external/cuba/src/divonne/Rule.c
+index 813b918..13d198c 100644
+--- a/external/cuba/src/divonne/Rule.c
++++ b/external/cuba/src/divonne/Rule.c
+@@ -582,19 +582,19 @@ static void Rule7Alloc(This *t)
+ 
+ static inline void RuleAlloc(This *t)
+ {
+-  if( (t->ndim - 2) | (t->key1 - 13)*(t->key2 - 13)*(t->key3 - 13) )
++  if( (t->ndim - 2) | ((t->key1 - 13) && (t->key2 - 13) && (t->key3 - 13)) )
+     t->rule13.first = NULL;
+   else Rule13Alloc(t);
+ 
+-  if( (t->ndim - 3) | (t->key1 - 11)*(t->key2 - 11)*(t->key3 - 11) )
++  if( (t->ndim - 3) | ((t->key1 - 11) && (t->key2 - 11) && (t->key3 - 11)) )
+     t->rule11.first = NULL;
+   else Rule11Alloc(t);
+ 
+-  if( (t->key1 - 9)*(t->key2 - 9)*(t->key3 - 9) )
++  if( (t->key1 - 9) && (t->key2 - 9) && (t->key3 - 9) )
+     t->rule9.first = NULL;
+   else Rule9Alloc(t);
+ 
+-  if( (t->key1 - 7)*(t->key2 - 7)*(t->key3 - 7) )
++  if( (t->key1 - 7) && (t->key2 - 7) && (t->key3 - 7) )
+     t->rule7.first = NULL;
+   else Rule7Alloc(t);
+ }

--- a/external/cuba/src/common/Random.c
+++ b/external/cuba/src/common/Random.c
@@ -102,7 +102,8 @@ static inline void SobolIni(This *t)
     int inibits = -1, bit;
     for( j = powers; j; j >>= 1 ) ++inibits;
 
-    memcpy(pv, pini, inibits*sizeof *pini);
+    if (inibits > 0)
+        memcpy(pv, pini, inibits*sizeof *pini);
     pini += 8;
 
     for( bit = inibits; bit <= nbits; ++bit ) {

--- a/external/cuba/src/divonne/Rule.c
+++ b/external/cuba/src/divonne/Rule.c
@@ -582,19 +582,19 @@ static void Rule7Alloc(This *t)
 
 static inline void RuleAlloc(This *t)
 {
-  if( (t->ndim - 2) | (t->key1 - 13)*(t->key2 - 13)*(t->key3 - 13) )
+  if( (t->ndim - 2) | ((t->key1 - 13) && (t->key2 - 13) && (t->key3 - 13)) )
     t->rule13.first = NULL;
   else Rule13Alloc(t);
 
-  if( (t->ndim - 3) | (t->key1 - 11)*(t->key2 - 11)*(t->key3 - 11) )
+  if( (t->ndim - 3) | ((t->key1 - 11) && (t->key2 - 11) && (t->key3 - 11)) )
     t->rule11.first = NULL;
   else Rule11Alloc(t);
 
-  if( (t->key1 - 9)*(t->key2 - 9)*(t->key3 - 9) )
+  if( (t->key1 - 9) && (t->key2 - 9) && (t->key3 - 9) )
     t->rule9.first = NULL;
   else Rule9Alloc(t);
 
-  if( (t->key1 - 7)*(t->key2 - 7)*(t->key3 - 7) )
+  if( (t->key1 - 7) && (t->key2 - 7) && (t->key3 - 7) )
     t->rule7.first = NULL;
   else Rule7Alloc(t);
 }

--- a/include/momemta/ParameterSet.h
+++ b/include/momemta/ParameterSet.h
@@ -90,7 +90,7 @@ class ParameterSet {
 
             try {
                 return momemta::any_cast<const T&>(value->second.value);
-            } catch (momemta::bad_any_cast e) {
+            } catch (const momemta::bad_any_cast& e) {
                 LOG(fatal) << "Exception while trying to get parameter '" << name << "'. Requested a '"
                            << demangle(typeid(T).name())
                            << "' while parameter is a '"
@@ -107,7 +107,7 @@ class ParameterSet {
 
             try {
                 return momemta::any_cast<T&>(value->second.value);
-            } catch (momemta::bad_any_cast e) {
+            } catch (const momemta::bad_any_cast& e) {
                 LOG(fatal) << "Exception while trying to get parameter '" << name << "'. Requested a '"
                            << demangle(typeid(T).name())
                            << "' while parameter is a '"
@@ -124,7 +124,7 @@ class ParameterSet {
 
             try {
                 return momemta::any_cast<const T&>(value->second.value);
-            } catch (momemta::bad_any_cast e) {
+            } catch (const momemta::bad_any_cast &e) {
                 LOG(fatal) << "Exception while trying to get parameter '" << name << "'. Requested a '"
                            << demangle(typeid(T).name())
                            << "' while parameter is a '"

--- a/include/momemta/impl/Pool.h
+++ b/include/momemta/impl/Pool.h
@@ -61,7 +61,7 @@ template <typename T> std::shared_ptr<const T> Pool::raw_get(const InputTag& tag
         std::shared_ptr<T>& ptr = momemta::any_cast<std::shared_ptr<T>&>(v.ptr);
 
         return std::const_pointer_cast<const T>(ptr);
-    } catch (momemta::bad_any_cast e) {
+    } catch (const momemta::bad_any_cast& e) {
         LOG(fatal) << "Exception while trying to get pool content for '" << tag.toString() << "'. Requested a '"
                    << demangle(typeid(std::shared_ptr<T>).name())
                    << "' while parameter is a '"


### PR DESCRIPTION
Some new warnings have been added in GCC8 (and already in 7 I think...). No biggie, but this suppresses them.

Note: based on #176, please merge that one first!